### PR TITLE
Fix/section buttons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ gunicorn==19.8.1
 # workaround: setup keeps installing wazimap from PYPI
 -e git+https://github.com/CodeForAfricaLabs/wazimap.git@master#egg=wazimap
 
+-e git+https://github.com/KhadijaMahanga/django-fontawesome.git@master#egg=django-fontawesome
+
 django-debug-toolbar

--- a/takwimu/models/dashboard.py
+++ b/takwimu/models/dashboard.py
@@ -1,4 +1,3 @@
-# encoding=utf-8
 from django.db import models
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel, PageChooserPanel, InlinePanel
 from wagtail.wagtailcore import blocks

--- a/takwimu/models/dashboard.py
+++ b/takwimu/models/dashboard.py
@@ -1,3 +1,4 @@
+# encoding=utf-8
 from django.db import models
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel, PageChooserPanel, InlinePanel
 from wagtail.wagtailcore import blocks
@@ -9,6 +10,7 @@ from modelcluster.fields import ParentalKey
 
 from wazimap.models import Geography
 from hurumap.models import DataTopic, DataIndicator
+from fontawesome.fields import IconField
 
 
 # The abstract model for data indicators, complete with panels
@@ -36,6 +38,7 @@ class TopicPage(Page):
     This therefore serves as an editorial interface to create topics and link indicators to it.
     '''
     description = models.TextField(blank=True)
+    icon = IconField()
 
     # TODO: For topics heirachy
     #parent_topic = models.ForeignKey('self',null=True,blank=True,on_delete=models.SET_NULL,related_name='+')
@@ -53,6 +56,7 @@ class TopicPage(Page):
 
     content_panels = Page.content_panels + [
         FieldPanel('description'),
+        FieldPanel('icon'),
         InlinePanel('data_indicators', label="Data Indicators"),
     ]
 
@@ -152,4 +156,3 @@ class ProfilePage(Page):
 
     def get_absolute_url(self):
         return self.full_url
-

--- a/takwimu/models/dashboard.py
+++ b/takwimu/models/dashboard.py
@@ -9,7 +9,7 @@ from modelcluster.fields import ParentalKey
 
 from wazimap.models import Geography
 from hurumap.models import DataTopic, DataIndicator
-from fontawesome.fields import IconField
+from fontawesome.fields import IconField #importing property from djano-fontawesome app for icons
 
 
 # The abstract model for data indicators, complete with panels
@@ -37,7 +37,7 @@ class TopicPage(Page):
     This therefore serves as an editorial interface to create topics and link indicators to it.
     '''
     description = models.TextField(blank=True)
-    icon = IconField()
+    icon = IconField()  #adding icon property that uses the djano-fontawesome app structure
 
     # TODO: For topics heirachy
     #parent_topic = models.ForeignKey('self',null=True,blank=True,on_delete=models.SET_NULL,related_name='+')

--- a/takwimu/settings.py
+++ b/takwimu/settings.py
@@ -4,7 +4,7 @@ import os
 from hurumap.settings import *  # noqa
 
 # insert our overrides before both census and hurumap
-INSTALLED_APPS = ['takwimu'] + INSTALLED_APPS + ['debug_toolbar']
+INSTALLED_APPS = ['takwimu'] + INSTALLED_APPS + ['debug_toolbar', 'fontawesome']
 
 ROOT_URLCONF = 'takwimu.urls'
 

--- a/takwimu/sql/takwimu_topicpage.sql
+++ b/takwimu/sql/takwimu_topicpage.sql
@@ -1,0 +1,86 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.5.12
+-- Dumped by pg_dump version 9.5.12
+
+-- Started on 2018-06-29 20:54:10 EAT
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- TOC entry 273 (class 1259 OID 44950)
+-- Name: takwimu_topicpage; Type: TABLE; Schema: public; Owner: takwimu
+--
+
+CREATE TABLE public.takwimu_topicpage (
+    page_ptr_id integer NOT NULL,
+    description text NOT NULL,
+    icon character varying
+);
+
+
+ALTER TABLE public.takwimu_topicpage OWNER TO takwimu;
+
+--
+-- TOC entry 2542 (class 0 OID 44950)
+-- Dependencies: 273
+-- Data for Name: takwimu_topicpage; Type: TABLE DATA; Schema: public; Owner: takwimu
+--
+
+COPY public.takwimu_topicpage (page_ptr_id, description, icon) FROM stdin;
+22		\N
+31		\N
+33	This is the boko haram section	\N
+34	Thus is a test oil economy section	\N
+35	This is a test of health topic with data indicators.	\N
+38		broadcast-tower
+39		chevron-circle-right
+16	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec interdum erat id mauris tempor vehicula. Integer vestibulum malesuada turpis ac placerat. Nunc sit amet mollis lorem. Cras blandit in arcu id suscipit. Curabitur in vulputate elit, id vestibulum arcu. Donec eget mi tellus. Donec ipsum dui, dapibus non suscipit sed, pellentesque ut purus.	university
+7	Healthiful	medkit
+6	Education things are important.	graduation-cap
+9	Agriculture Things	subway
+13	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec interdum erat id mauris tempor vehicula. Integer vestibulum malesuada turpis ac placerat. Nunc sit amet mollis lorem. Cras blandit in arcu id suscipit. Curabitur in vulputate elit, id vestibulum arcu. Donec eget mi tellus. Donec ipsum dui, dapibus non suscipit sed, pellentesque ut purus.	chart-bar
+15	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec interdum erat id mauris tempor vehicula. Integer vestibulum malesuada turpis ac placerat. Nunc sit amet mollis lorem. Cras blandit in arcu id suscipit. Curabitur in vulputate elit, id vestibulum arcu. Donec eget mi tellus. Donec ipsum dui, dapibus non suscipit sed, pellentesque ut purus.	chart-bar
+17	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec interdum erat id mauris tempor vehicula. Integer vestibulum malesuada turpis ac placerat. Nunc sit amet mollis lorem. Cras blandit in arcu id suscipit. Curabitur in vulputate elit, id vestibulum arcu. Donec eget mi tellus. Donec ipsum dui, dapibus non suscipit sed, pellentesque ut purus.	users
+20	Nigeria’s federal structure was designed to ensure adequate political representation and allocation of resources across the country. However, the system also fosters competition between government tiers over control of resources, and has left many states heavily dependent on their federal allocation rather than developing their own viable tax base.	university
+40		crosshairs
+\.
+
+
+--
+-- TOC entry 2426 (class 2606 OID 45386)
+-- Name: takwimu_topicpage_pkey; Type: CONSTRAINT; Schema: public; Owner: takwimu
+--
+
+ALTER TABLE ONLY public.takwimu_topicpage
+    ADD CONSTRAINT takwimu_topicpage_pkey PRIMARY KEY (page_ptr_id);
+
+
+--
+-- TOC entry 2427 (class 2606 OID 45759)
+-- Name: takwimu_topicpage_page_ptr_id_5d17d7d2_fk_wagtailcore_page_id; Type: FK CONSTRAINT; Schema: public; Owner: takwimu
+--
+
+ALTER TABLE ONLY public.takwimu_topicpage
+    ADD CONSTRAINT takwimu_topicpage_page_ptr_id_5d17d7d2_fk_wagtailcore_page_id FOREIGN KEY (page_ptr_id) REFERENCES public.wagtailcore_page(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+-- Completed on 2018-06-29 20:54:10 EAT
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/takwimu/templates/takwimu/_includes/header/profile.html
+++ b/takwimu/templates/takwimu/_includes/header/profile.html
@@ -54,13 +54,15 @@
 
   </div>
   <div class="py-5 bg-light">
-    <div class="d-flex flex-row justify-content-center text-uppercase">
-      {% for topic in page.topics.all %}
-        <div class="col-2 border-right text-center">
-          <p><i class="fas fa-{{ topic.topic.icon }} fa-2x text-primary"></i></p>
-          <p><a href={{ topic.topic.url }}>{{ topic.topic }}</a></p>
-        </div>
-      {% endfor %}
+    <div class="container">
+      <div class="d-flex flex-row justify-content-center text-uppercase">
+        {% for topic in page.topics.all %}
+          <div class="col-2 border-right text-center">
+            <p><i class="fas fa-{{ topic.topic.icon }} fa-2x text-primary"></i></p>
+            <p><a href={{ topic.topic.url }}>{{ topic.topic }}</a></p>
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 

--- a/takwimu/templates/takwimu/_includes/header/profile.html
+++ b/takwimu/templates/takwimu/_includes/header/profile.html
@@ -6,7 +6,7 @@
     <div class="container">
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb bg-white">
-          <li class="breadcrumb-item"><a href="/">Home</a></li> 
+          <li class="breadcrumb-item"><a href="/">Home</a></li>
           <li class="breadcrumb-item"><a href="/profiles">Country Profiles</a></li>
           {% if page.content_type.model == "profilesectionpage" %}
           <li class="breadcrumb-item"><a href="{{ page.get_parent.url }}">{{ page.get_parent.title }}</a></li>
@@ -14,11 +14,11 @@
           <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
         </ol>
       </nav>
-  
+
       <div class="d-flex justify-content-between align-items-center">
-        
+
         {% include 'takwimu/_includes/profile/country_selector.html' %}
-        
+
         <!-- TOC Button -->
         <button
             class="btn btn-light btn-lg text-uppercase pr-4"
@@ -28,7 +28,7 @@
         </button>
 
       </div>
-  
+
       <div class="text-center">
         {% if page.content_type.model == "profilesectionpage" %}
 
@@ -37,11 +37,11 @@
         <p class="lead my-4 mx-auto" style="max-width: 780px;">{{ page.description }}</p>
 
         {% else %}
-        
+
         <p class="strong text-uppercase">Section 1</p>
         <h1 class="display-1">Country Overview</h1>
         <p class="lead my-4 mx-auto" style="max-width: 780px;">A top-level overview of Nigeria – how it’s governed, the make-up of it’s population, the economy and SDG indicators</p>
-        
+
         {% endif %}
 
         <a class="btn btn-primary btn-sm text-uppercase px-2 py-1 disabled" href="#" role="button"
@@ -49,28 +49,18 @@
           Download full country profile <i class="fas fa-download border-left pl-2 ml-1"></i>
         </a>
       </div>
-        
+
     </div>
 
   </div>
   <div class="py-5 bg-light">
     <div class="d-flex flex-row justify-content-center text-uppercase">
+      {% for topic in page.topics.all %}
         <div class="col-2 border-right text-center">
           <p><i class="fas fa-university fa-2x text-primary"></i></p>
-          <p><a href="#">Governance</a></p>
+          <p><a href={{ topic.topic.url }}>{{ topic.topic }}</a></p>
         </div>
-        <div class="col-2 border-right text-center">
-          <p><i class="fas fa-users fa-2x text-primary"></i></p>
-          <p><a href="#">The People</a></p>
-        </div>
-        <div class="col-2 border-right text-center">
-          <p><i class="fas fa-chart-bar fa-2x text-primary"></i></p>
-          <p><a href="#">The Economy</a></p>
-        </div>
-        <div class="col-2 text-center">
-          <p><i class="fas fa-leaf fa-2x text-primary"></i></p>
-          <p><a href="#" >Sustainable Development Goals</a></p>
-          </div>
+      {% endfor %}
     </div>
   </div>
 

--- a/takwimu/templates/takwimu/_includes/header/profile.html
+++ b/takwimu/templates/takwimu/_includes/header/profile.html
@@ -57,7 +57,7 @@
     <div class="d-flex flex-row justify-content-center text-uppercase">
       {% for topic in page.topics.all %}
         <div class="col-2 border-right text-center">
-          <p><i class="fas fa-university fa-2x text-primary"></i></p>
+          <p><i class="fas fa-{{ topic.topic.icon }} fa-2x text-primary"></i></p>
           <p><a href={{ topic.topic.url }}>{{ topic.topic }}</a></p>
         </div>
       {% endfor %}


### PR DESCRIPTION
## Description

We are now able to select icon for topic model in our CMS. In addition, the topic buttons div on the web profile page is no longer static. The div now displays associated profile's topics with their personalized icons (get pulled from views).
Note:
-This fix has changed the table structure of `takwimu_topicpage` by adding an extra column called icon therefore needs to be adjusted. I have added an sql file for takwimu_topicpage with the structure changes and sample data under takwimu/sql folder.
-On icon selection, we have used a django app that allows font-awesome icon dropdown and selection,  `[django-fontawesome`](https://github.com/CodeForAfricaLabs/django-fontawesomel) which will need to be installed. Please run `pip install -r requirements.txt`

Fixes #109 

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Screenshots
Icon selection for topic
![screenshot from 2018-06-29 19-59-29](https://user-images.githubusercontent.com/7962097/42106097-745796ca-7bdb-11e8-8776-ca181be8cf80.png)

Topic Button Display
![screenshot from 2018-06-29 19-58-41](https://user-images.githubusercontent.com/7962097/42106127-91187cde-7bdb-11e8-9d92-ba6a7f44e303.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation