### PR TITLE
fixed icons with different style

### DIFF
--- a/takwimu/templates/takwimu/_includes/header/profile.html
+++ b/takwimu/templates/takwimu/_includes/header/profile.html
@@ -60,7 +60,7 @@
       <div class="d-flex flex-row justify-content-center text-uppercase">
         {% for topic in page.body %}
           <div class="col-2 border-right text-center">
-            <p><i class="fas fa-{{ topic.value.icon }} fa-2x text-primary"></i></p>
+            <p><i class="{{ topic.value.icon }} fa-2x text-primary"></i></p>
             <p><a href="#{{ topic.title|slugify }}">{{ topic.value.title }}</a></p>
           </div>
         {% endfor %}


### PR DESCRIPTION
## Description
 This fixes icons that have blank square. Before font-awesome icons were appended by fas `e.g. fas fa-icon` which is solid style in Font Awesome 5. The fix was mostly done in `django-fontawesome` package where icons are now appended by either `fas`, `fab`, or `far` depending on its stated style in `icons.yml`. Changes in this PR accommodate the new icon drop down value which is used to display icon in topic buttons div.
Run `pip install -r requirements.txt` to get recent changes on `django-fontawesome`

Fixes #137

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![screenshot from 2018-07-04 16-31-49](https://user-images.githubusercontent.com/7962097/42281288-c32e643a-7fab-11e8-852e-675058c87f5e.png)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation