### PR TITLE
[HURUmap] Override profile detail template

### DIFF
--- a/takwimu/static/css/takwimu.scss
+++ b/takwimu/static/css/takwimu.scss
@@ -21,7 +21,9 @@ body {
   padding-top: 56px;
 }
 
-* {
+// hurumap.css provides default font family for these elements: html, body, h4, h5, h6, & p
+// and hence we must overide the (CSS Specificity Hierarchy)
+ html, body, h4, h5, h6, p, * {
   font-family: 'Montserrat', sans-serif;
   word-break: break-word;
 }

--- a/takwimu/static/css/takwimu.scss
+++ b/takwimu/static/css/takwimu.scss
@@ -21,8 +21,8 @@ body {
   padding-top: 56px;
 }
 
-// hurumap.css provides default font family for these elements: html, body, h4, h5, h6, & p
-// and hence we must overide the (CSS Specificity Hierarchy)
+// hurumap.css provides default font family for these elements: html, body, h4, h5, h6 & p
+// thus we must overide them (CSS Specificity Hierarchy)
  html, body, h4, h5, h6, p, * {
   font-family: 'Montserrat', sans-serif;
   word-break: break-word;

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -200,10 +200,6 @@
   {% include 'takwimu/_includes/footer.html' %}
 
   <style>
-    footer p {
-      font-family: 'Montserrat', sans-serif;
-      word-break: break-word;
-    }
     #profile {
       background-color: #ffffff;
     }

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -25,170 +25,182 @@
   </div>
 
 {% endblock %}
+{% block content_container %}
+  <div class="content-container wrapper clearfix">
+    {% block profile_preamble %} {% endblock %}
 
-{% block profile_preamble %} {% endblock %}
-
-{% block profile_detail %}
-  <article
-      class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
-    <header class="section-contents">
-      <h1>HDI Overview</h1>
-    </header>
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=hdi_overview.hdi stat_type='number' %}
+    {% block profile_detail %}
+      <article
+          class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
+        <header class="section-contents">
+          <h1>HDI Overview</h1>
+        </header>
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=hdi_overview.hdi stat_type='number' %}
+            </div>
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=hdi_overview.rank stat_type='number' %}
+            </div>
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=hiv_prevalence.current_prevalence stat_type='percentage' %}
+            </div>
+          </section>
         </div>
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=hdi_overview.rank stat_type='number' %}
+        <div class="section-container">
+          <section class="clearfix stat-row">
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.forest_area__of_total_land_area stat_type='percentage' %}
+            </div>
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.population_living_below_income_poverty_line_ppp_190_a_day_ stat_type='percentage' %}
+            </div>
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.pupil_teacher_ratio_primary_school stat_type='number' %}
+            </div>
+          </section>
         </div>
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=hiv_prevalence.current_prevalence stat_type='percentage' %}
+        <div class="section-container">
+          <section class="clearfix stat-row">
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.homicide_rate_per_100000_people stat_type='number' %}
+            </div>
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.public_health_expenditure_of_gdp stat_type='percentage' %}
+            </div>
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.internet_users__of_population stat_type='percentage' %}
+            </div>
+          </section>
         </div>
-      </section>
-    </div>
-    <div class="section-container">
-      <section class="clearfix stat-row">
+        <div class="section-container">
+          <section class="clearfix stat-row">
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.forest_area__of_total_land_area stat_type='percentage' %}
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.gender_development_index stat_type='number' %}
+            </div>
+
+
+            <div class="column-third">
+              {% include 'profile/_blocks/_stat_list.html' with stat=landscape.domestic_food_price_level_index stat_type='number' %}
+            </div>
+          </section>
+
+        </div>
+      </article>
+      <article
+          class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
+        <header class="section-contents">
+          <h1>Economy</h1>
+        </header>
+        <div class="section-container">
+
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-gdp-gdp"
+                 data-stat-type="number"
+                 data-chart-title="GDP in billions of US$"></div>
+          </section>
+
+        </div>
+      </article>
+
+      <article
+          class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
+        <header class="section-contents">
+          <h1>Health</h1>
+        </header>
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-life_expectancy-life_expectancy"
+                 data-stat-type="number"
+                 data-chart-title="Life Expectancy For the last 10 years"></div>
+          </section>
+
         </div>
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.population_living_below_income_poverty_line_ppp_190_a_day_ stat_type='percentage' %}
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-hiv_prevalence-HIV"
+                 data-stat-type="scaled-percentage"
+                 data-chart-title="HIV Prevalence For the last 10 years as a % of the population aged 15 - 49"></div>
+          </section>
+
         </div>
+      </article>
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.pupil_teacher_ratio_primary_school stat_type='number' %}
+      <article
+          class="clearfix">
+        <header class="section-contents">
+          <h1>Census</h1>
+        </header>
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <h4>Population 2016</h4>
+            {% include 'profile/_blocks/_stat_list.html' with stat=demographics.total_population stat_type='number' %}
+          </section>
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-demographics-population_dist"
+                 data-stat-type="number"
+                 data-chart-title="Population For the last 5 years"></div>
+          </section>
+
         </div>
-      </section>
-    </div>
-    <div class="section-container">
-      <section class="clearfix stat-row">
+      </article>
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.homicide_rate_per_100000_people stat_type='number' %}
+      <article
+          class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
+        <header class="section-contents">
+          <h1>Education</h1>
+        </header>
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-literacy-literacy"
+                 data-stat-type="scaled-percentage"
+                 data-chart-title="Literate Percentage of population above 15 years"></div>
+          </section>
+
         </div>
+      </article>
+      <article
+          class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
+        <header class="section-contents">
+          <h1>Agriculture</h1>
+        </header>
+        <div class="section-container">
+          <section class="clearfix stat-row">
+            <div class="column-full"
+                 id="chart-histogram-crops-crop"
+                 data-stat-type="number"
+                 data-chart-title="Crop Production Index For the last 10 years"></div>
+          </section>
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.public_health_expenditure_of_gdp stat_type='percentage' %}
         </div>
+      </article>
+    {% endblock %}
+  </div>
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.internet_users__of_population stat_type='percentage' %}
-        </div>
-      </section>
-    </div>
-    <div class="section-container">
-      <section class="clearfix stat-row">
+  {# Footer #}
+  {% include 'takwimu/_includes/footer.html' %}
 
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.gender_development_index stat_type='number' %}
-        </div>
+  <style>
+    #page-footer {
+      display: none;
+    }
+  </style>
 
-
-        <div class="column-third">
-          {% include 'profile/_blocks/_stat_list.html' with stat=landscape.domestic_food_price_level_index stat_type='number' %}
-        </div>
-      </section>
-
-    </div>
-  </article>
-  <article
-      class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
-    <header class="section-contents">
-      <h1>Economy</h1>
-    </header>
-    <div class="section-container">
-
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-gdp-gdp"
-             data-stat-type="number"
-             data-chart-title="GDP in billions of US$"></div>
-      </section>
-
-    </div>
-  </article>
-
-  <article
-      class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
-    <header class="section-contents">
-      <h1>Health</h1>
-    </header>
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-life_expectancy-life_expectancy"
-             data-stat-type="number"
-             data-chart-title="Life Expectancy For the last 10 years"></div>
-      </section>
-
-    </div>
-
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-hiv_prevalence-HIV"
-             data-stat-type="scaled-percentage"
-             data-chart-title="HIV Prevalence For the last 10 years as a % of the population aged 15 - 49"></div>
-      </section>
-
-    </div>
-  </article>
-
-  <article
-      class="clearfix">
-    <header class="section-contents">
-      <h1>Census</h1>
-    </header>
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <h4>Population 2016</h4>
-        {% include 'profile/_blocks/_stat_list.html' with stat=demographics.total_population stat_type='number' %}
-      </section>
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-demographics-population_dist"
-             data-stat-type="number"
-             data-chart-title="Population For the last 5 years"></div>
-      </section>
-
-    </div>
-  </article>
-
-  <article
-      class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
-    <header class="section-contents">
-      <h1>Education</h1>
-    </header>
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-literacy-literacy"
-             data-stat-type="scaled-percentage"
-             data-chart-title="Literate Percentage of population above 15 years"></div>
-      </section>
-
-    </div>
-  </article>
-  <article
-      class="clearfix {% if 'demographics' not in selected_sections %}hide{% endif %}">
-    <header class="section-contents">
-      <h1>Agriculture</h1>
-    </header>
-    <div class="section-container">
-      <section class="clearfix stat-row">
-        <div class="column-full"
-             id="chart-histogram-crops-crop"
-             data-stat-type="number"
-             data-chart-title="Crop Production Index For the last 10 years"></div>
-      </section>
-
-    </div>
-  </article>
 {% endblock %}
-
 {% block body_javascript %}
   <script src="{% static 'js/vendor/modernizr-3.6.0.min.js' %}"></script>
   <script src="{% static 'js/plugins.js' %}"></script>
@@ -243,5 +255,4 @@
 
 {% endblock body_javascript %}
 
-{# Footer #}
-{% include 'takwimu/_includes/footer.html' %}
+

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -5,7 +5,6 @@
   {{ block.super }}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/bootstrap@4.1.1/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{% sass_src 'css/takwimu.scss' %}">
-
 {% endblock %}
 
 {% block header %}
@@ -15,7 +14,6 @@
   {% block header_content %}
     {% block secondary_nav %} {% endblock %}
     {{ block.super }}
-
   {% endblock %}
 {% endblock %}
 
@@ -23,8 +21,8 @@
   <div class="column-full">
     <p class="caption"><strong>Census data:</strong> 2014</p>
   </div>
-
 {% endblock %}
+
 {% block content_container %}
   <div class="content-container wrapper clearfix">
     {% block profile_preamble %} {% endblock %}
@@ -205,15 +203,17 @@
     #profile {
       background-color: #ffffff;
     }
+
     #page-footer {
       display: none;
     }
+
     .updates {
       margin-bottom: 0;
     }
   </style>
-
 {% endblock %}
+
 {% block body_javascript %}
   <script src="{% static 'js/vendor/modernizr-3.6.0.min.js' %}"></script>
   <script src="{% static 'js/plugins.js' %}"></script>

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -191,6 +191,15 @@
     {% endblock %}
   </div>
 
+  {% include 'takwimu/_includes/sections/support-services/button.html' %}
+
+  {% include 'takwimu/_includes/sections/stories/index.html' %}
+
+  <!-- Country profile country select -->
+  {% include 'takwimu/_includes/sections/explore/_index.html' %}
+
+  {% include 'takwimu/_includes/sections/updates.html' %}
+
   {# Footer #}
   {% include 'takwimu/_includes/footer.html' %}
 

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -1,4 +1,23 @@
 {% extends 'profile/profile_detail.html' %}
+{% load staticfiles sass_tags %}
+
+{% block head_css %}
+  {{ block.super }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/bootstrap@4.1.1/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{% sass_src 'css/takwimu.scss' %}">
+
+{% endblock %}
+
+{% block header %}
+  {# Navbar #}
+  {% include 'takwimu/_includes/navbar/_index.html' %}
+
+  {% block header_content %}
+    {% block secondary_nav %} {% endblock %}
+    {{ block.super }}
+
+  {% endblock %}
+{% endblock %}
 
 {% block profile_header_tail %}
   <div class="column-full">
@@ -6,6 +25,8 @@
   </div>
 
 {% endblock %}
+
+{% block profile_preamble %} {% endblock %}
 
 {% block profile_detail %}
   <article
@@ -167,3 +188,60 @@
     </div>
   </article>
 {% endblock %}
+
+{% block body_javascript %}
+  <script src="{% static 'js/vendor/modernizr-3.6.0.min.js' %}"></script>
+  <script src="{% static 'js/plugins.js' %}"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha256-98vAGjEDGN79TjHkYWVD4s87rvWkdWLHPs5MC3FvFX4=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha256-xaF9RpdtRxzwYMWg4ldJoyPWqyDPCRD0Cv7YEEe6Ie8=" crossorigin="anonymous"></script>
+  <script src="{% static 'js/main.js' %}"></script>
+  <script src="{% static 'js/svg.js' %}"></script>
+  <script defer data-search-pseudo-elements src="https://use.fontawesome.com/releases/v5.1.0/js/all.js" integrity="sha384-3LK/3kTpDE/Pkp8gTNp2gR/2gOiwQ6QaO7Td0zV76UFJVhqLl4Vl3KL1We6q6wR9" crossorigin="anonymous"></script>
+
+  <!-- Start of takwimu Zendesk Widget script -->
+  <script>/*<![CDATA[*/
+  window.zE || (function (e, t, s) {
+      var n = window.zE = window.zEmbed = function () {
+          n._.push(arguments)
+      }, a = n.s = e.createElement(t), r = e.getElementsByTagName(t)[0];
+      n.set = function (e) {
+          n.set._.push(e)
+      }, n._ = [], n.set._ = [], a.async = true, a.setAttribute("charset", "utf-8"), a.src = "https://static.zdassets.com/ekr/asset_composer.js?key=" + s, n.t = +new Date, a.type = "text/javascript", r.parentNode.insertBefore(a, r)
+  })(document, "script", "db3ec064-4699-489e-a829-d337d290b7e7");
+  /*]]>*/</script>
+  <!-- End of takwimu Zendesk Widget script -->
+
+  <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
+  <script>
+      window.ga = function () {
+          ga.q.push(arguments)
+      };
+      ga.q = [];
+      ga.l = +new Date;
+      ga('create', '{{ HURUmap.ga_tracking_id }}', 'auto');
+      ga('send', 'pageview')
+      {% for ga_tracking_id in HURUMAP.ga_tracking_ids %}
+          ga('create', '{{ ga_tracking_id }}', 'auto', {'name': 't{{ forloop.counter }}'});
+          ga('t{{ forloop.counter }}.send', 'pageview');
+      {% endfor %}
+  </script>
+  <script src="https://www.google-analytics.com/analytics.js" async defer></script>
+
+  <!-- Bootstrap: Enable Tooltips -->
+  <script>
+      $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+      })
+  </script>
+
+  {% block body_javascript_extra %}
+    {{ block.super }}
+  {% endblock %}
+
+  {{ block.super }}
+
+{% endblock body_javascript %}
+
+{# Footer #}
+{% include 'takwimu/_includes/footer.html' %}

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -193,8 +193,6 @@
 
   {% include 'takwimu/_includes/sections/support-services/button.html' %}
 
-  {% include 'takwimu/_includes/sections/stories/index.html' %}
-
   <!-- Country profile country select -->
   {% include 'takwimu/_includes/sections/explore/_index.html' %}
 
@@ -204,8 +202,14 @@
   {% include 'takwimu/_includes/footer.html' %}
 
   <style>
+    #profile {
+      background-color: #ffffff;
+    }
     #page-footer {
       display: none;
+    }
+    .updates {
+      margin-bottom: 0;
     }
   </style>
 

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -200,6 +200,10 @@
   {% include 'takwimu/_includes/footer.html' %}
 
   <style>
+    footer p {
+      font-family: 'Montserrat', sans-serif;
+      word-break: break-word;
+    }
     #profile {
       background-color: #ffffff;
     }

--- a/takwimu/templates/profile/profile_detail_census.html
+++ b/takwimu/templates/profile/profile_detail_census.html
@@ -1,1 +1,0 @@
-{% extends 'profile/profile_detail.html' %}

--- a/takwimu/templates/profile/profile_detail_takwimu.html
+++ b/takwimu/templates/profile/profile_detail_takwimu.html
@@ -1,5 +1,0 @@
-{% extends 'profile/profile_detail.html' %}
-
-{% block profile_detail %}
-Woot
-{% endblock %}

--- a/takwimu/urls.py
+++ b/takwimu/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.views.generic import RedirectView
 from hurumap.urls import urlpatterns as hurumap_urlpatterns
+from wazimap.views import HomepageView
 
 from takwimu import settings
 


### PR DESCRIPTION
## Description

Override the HURUmap profile/profile_detail.html template to use a Takwimu base template.
Focus should be on the navbar, footer and the general look and feel to match Takwimu

Fixes #194 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Screenshots
![screencapture-localhost-8000-profiles-country-nga-nigeria-2018-07-16-15_13_37](https://user-images.githubusercontent.com/13383422/42758470-52b73fa0-890c-11e8-976f-5d6daa8cab83.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation