### PR TITLE
add a country map section in profile details that directs to analysis

### DIFF
--- a/takwimu/templates/homepage.html
+++ b/takwimu/templates/homepage.html
@@ -49,35 +49,7 @@
     <section class="m-0">
       {% with countries='nigeria tanzania senegal' %}
         {% for country in countries.split %}
-          <div class="jumbotron jumbotron-fluid py-5 mb-0 container-fluid country-container">
-            <div class="container">
-              <div class="row">
-                <div class="col-4">
-                  <img class=" border-light mr-2"
-                       src={% with 'img/maps/'|add:country|lower|add:'.svg' as image_static %}
-                         {% static image_static %}
-                       {% endwith %}/>
-                </div>
-                <div class="col-8">
-                  <h2 class="display-4 font-weight-bold mb-4">{{ country|title }}</h2>
-                  <p class="mb-0" style="color: #4a4a4a;">
-                    Actionable analysis by geo-political and socioeconomic experts across 10 key African countries.
-                  </p>
-                  <p class="font-weight-bold mt-4">
-                    <!-- Show data at:
-                    <select class="ml-2 py-2"
-                            style="padding-right: 2em; padding-left: 2px; border-color: rgb(169, 169, 169); height: auto">
-                      <option value="National Level">National Level</option>
-                    </select> -->
-                    <a class="btn btn-primary btn-sm text-uppercase font-weight-bold" href="/profiles/{{ country }}"
-                       style="border-color: #1f6cc6; padding-top:9px; padding-bottom: 9px;">
-                      Read Country Analysis For {{ country|upper }}
-                    </a>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
+          {% include 'takwimu/_includes/profile/country_section.html' with country=country %}
         {% endfor %}
       {% endwith %}
 

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -176,7 +176,7 @@
         <header class="section-contents">
           <h1>Agriculture</h1>
         </header>
-        <div class="section-container" style="border-bottom: 0">
+        <div class="section-container border-bottom-0">
           <section class="clearfix stat-row">
             <div class="column-full"
                  id="chart-histogram-crops-crop"

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -176,7 +176,7 @@
         <header class="section-contents">
           <h1>Agriculture</h1>
         </header>
-        <div class="section-container">
+        <div class="section-container" style="border-bottom: 0">
           <section class="clearfix stat-row">
             <div class="column-full"
                  id="chart-histogram-crops-crop"
@@ -188,7 +188,7 @@
       </article>
     {% endblock %}
   </div>
-  {% include 'takwimu/_includes/profile/country_section.html' with country=geography.this.short_name|lower %}
+  {% include 'takwimu/_includes/profile/country_section.html' with country=geography.this.short_name|lower title='long' %}
 
   {% include 'takwimu/_includes/sections/support-services/button.html' %}
 
@@ -205,7 +205,8 @@
       background-color: #ffffff;
     }
     .country-container {
-      background-color: #f4f4f4;
+      background-color: #f9f9f9;
+      height: 400px;
     }
 
     #page-footer {

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -188,6 +188,7 @@
       </article>
     {% endblock %}
   </div>
+  {% include 'takwimu/_includes/profile/country_section.html' with country=geography.this.short_name|lower %}
 
   {% include 'takwimu/_includes/sections/support-services/button.html' %}
 
@@ -202,6 +203,9 @@
   <style>
     #profile {
       background-color: #ffffff;
+    }
+    .country-container {
+      background-color: #f4f4f4;
     }
 
     #page-footer {
@@ -267,5 +271,3 @@
   {{ block.super }}
 
 {% endblock body_javascript %}
-
-

--- a/takwimu/templates/takwimu/_includes/profile/country_section.html
+++ b/takwimu/templates/takwimu/_includes/profile/country_section.html
@@ -1,0 +1,30 @@
+{% load staticfiles %}
+<div class="jumbotron jumbotron-fluid py-5 mb-0 container-fluid country-container">
+  <div class="container">
+    <div class="row">
+      <div class="col-4">
+        <img class=" border-light mr-2"
+             src={% with 'img/maps/'|add:country|lower|add:'.svg' as image_static %}
+               {% static image_static %}
+             {% endwith %}/>
+      </div>
+      <div class="col-8">
+        <h2 class="display-4 font-weight-bold mb-4">{{ country|title }}</h2>
+        <p class="mb-0" style="color: #4a4a4a;">
+          Actionable analysis by geo-political and socioeconomic experts across 10 key African countries.
+        </p>
+        <p class="font-weight-bold mt-4">
+          <!-- Show data at:
+          <select class="ml-2 py-2"
+                  style="padding-right: 2em; padding-left: 2px; border-color: rgb(169, 169, 169); height: auto">
+            <option value="National Level">National Level</option>
+          </select> -->
+          <a class="btn btn-primary btn-sm text-uppercase font-weight-bold" href="/profiles/{{ country }}"
+             style="border-color: #1f6cc6; padding-top:9px; padding-bottom: 9px;">
+            Read Country Analysis For {{ country|upper }}
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/takwimu/templates/takwimu/_includes/profile/country_section.html
+++ b/takwimu/templates/takwimu/_includes/profile/country_section.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 <div class="jumbotron jumbotron-fluid py-5 mb-0 container-fluid country-container">
-  <div class="container">
+  <div class="container pt-4">
     <div class="row">
       <div class="col-4">
         <img class=" border-light mr-2"
@@ -9,7 +9,7 @@
              {% endwith %}/>
       </div>
       <div class="col-8">
-        <h2 class="display-4 font-weight-bold mb-4">{{ country|title }}</h2>
+        <h2 class="display-4 font-weight-bold mb-4">{{ country|title}}{% if title %}'s Country Profile{% endif %}</h2>
         <p class="mb-0" style="color: #4a4a4a;">
           Actionable analysis by geo-political and socioeconomic experts across 10 key African countries.
         </p>


### PR DESCRIPTION
## Description
Added a section on hurumap country profile page with a button that can direct user to country analysis. I added a new layout `country-section` to be included in country profile landing page, and profile detail landing page

Fixes #252

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
**Profile Details Page with `country-section` layout after data viz**
![screenshot from 2018-07-24 12-02-22](https://user-images.githubusercontent.com/7962097/43127993-81ec92ec-8f39-11e8-8561-244a7b622c27.png)

**Profile Laniding Page with `country-section` layout after map**
![screenshot from 2018-07-24 13-43-18](https://user-images.githubusercontent.com/7962097/43133622-099b52e2-8f48-11e8-9c59-f09c3019c8c0.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation