### PR TITLE
Fixes "Link to community forum broken"

### DIFF
--- a/takwimu/templates/takwimu/_includes/navbar/support_services.html
+++ b/takwimu/templates/takwimu/_includes/navbar/support_services.html
@@ -57,7 +57,7 @@
             <a href="{{ settings.takwimu.SupportSetting.zendesk }}" target="_blank" rel="noopener"><u>Technical Support Desk</u></a>
           </li>
           <li class="pb-2" type="disc">
-            <a href="#" target="_blank"><u>Community Forum</u></a>
+            <a href="{{ settings.takwimu.SupportSetting.community }}" target="_blank"><u>Community Forum</u></a>
           </li>
           <li class="pb-2" type="disc"><a href="/about"><u>About Us</u></a></li>
         </ul>


### PR DESCRIPTION
## Description

Set "Community Forum" link to `SupportSetting.community` url.

Fixes #273

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation