### PR TITLE
Fixes "About Us link is broken"

### DIFF
--- a/takwimu/templates/takwimu/_includes/navbar/support_services.html
+++ b/takwimu/templates/takwimu/_includes/navbar/support_services.html
@@ -59,7 +59,7 @@
           <li class="pb-2" type="disc">
             <a href="#" target="_blank"><u>Community Forum</u></a>
           </li>
-          <li class="pb-2" type="disc"><a href="/about"><u>About Us</u></a></li>
+          <li class="pb-2" type="disc"><a href="/about/"><u>About Us</u></a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Description

There was a missing '/' in **About Us** link.

Fixes #274 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation