### PR TITLE
Fix: Country analysis section for sub-national level profile view

### DIFF
--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -70,7 +70,18 @@
       </article>
     {% endblock %}
   </div>
-  {% include 'takwimu/_includes/profile/country_section.html' with country=geography.this.short_name|lower title='long' %}
+
+  {% if geography.this.geo_level == 'country' %}
+    {% include 'takwimu/_includes/profile/country_section.html' with country=geography.this.short_name|lower title='long' %}
+  {% else %}
+    {% if geography.parents %}
+        {% for level, g in geography.parents.items %}
+          {% if g.geo_level == 'country' %}
+            {% include 'takwimu/_includes/profile/country_section.html' with country=g.short_name|lower title='long' %}
+          {%endif%}
+        {% endfor %}
+    {% endif %}
+  {% endif %}
 
   {% include 'takwimu/_includes/sections/support-services/button.html' %}
 


### PR DESCRIPTION
## Description
`country map` section on Profile detail view for geography levels below country now directs user to their specific parent country analysis fixing the existing bug on develop branch which directs user to level analysis (does not exist)

Fixes #297 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![screenshot from 2018-08-01 10-42-59](https://user-images.githubusercontent.com/7962097/43509311-01152272-957b-11e8-90cc-ccbbbe73a335.png)


## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation