### PR TITLE
fix anchor navigation

### DIFF
--- a/takwimu/templates/takwimu/_includes/profile/topic_detail.html
+++ b/takwimu/templates/takwimu/_includes/profile/topic_detail.html
@@ -1,7 +1,7 @@
 {% load staticfiles wagtailcore_tags %}
 
-<div class="container-fluid data-topic-container">
-  <div class="container py-5 data-topic">
+<div class="container-fluid data-topic-container" id="{{ topic.value.title|slugify }}">
+  <div class="container data-topic">
     <div class="row">
 
       <!-- Left navigation of all indicators-->
@@ -34,11 +34,11 @@
               <a class="pl-3 font-weight-bold" href="{{ settings.takwimu.SupportSetting.zendesk }}" target="_blank" rel="noopener"
                   style="text-decoration: none;">
                 <span class="mr-1"><i class="fas fa-comments fa-lg"></i></span> Have your say</a>
-          </div>
+      </div>
     </div>  <!-- /.col-3 -->
 
     <!-- The Main Stage -->
-    <div id="{{ topic.value.title|slugify }}" class="col-9 topic topic-{{ topic.value.title|slugify }}">
+    <div class="col-9 topic topic-{{ topic.value.title|slugify }}">
       <h1>{{ topic.value.title }}</h1>
       <div class="text-dark">
         <p>{{ topic.value.summary }}</p>
@@ -122,6 +122,10 @@
 
   .topic h5{
     font-size: 25px;
+  }
+  .data-topic {
+    padding-top: 72px;
+    padding-bottom: 72px;
   }
 
   .topic .btn-group .btn{

--- a/takwimu/templates/takwimu/_includes/profile/topic_detail.html
+++ b/takwimu/templates/takwimu/_includes/profile/topic_detail.html
@@ -1,7 +1,7 @@
 {% load staticfiles wagtailcore_tags %}
 
-<div class="container-fluid data-topic-container" id="{{ topic.value.title|slugify }}">
-  <div class="container data-topic">
+<div class="container-fluid data-topic-container py-4" id="{{ topic.value.title|slugify }}">
+  <div class="container py-5">
     <div class="row">
       <!-- Left navigation of all indicators-->
       <div class="col-3 dataindicators-nav">
@@ -128,11 +128,6 @@
   .topic h5{
     font-size: 25px;
   }
-  .data-topic {
-    padding-top: 72px;
-    padding-bottom: 72px;
-  }
-
   .topic .btn-group .btn{
     border-radius: 2px;
     color: #1a1a1a;


### PR DESCRIPTION
## Description
This PR fixes the topic anchor navigation bug. It changes the anchor target to the div tag that contain the entire data topic, and not a sub-child tag element as it was before. Also adjusted the y-padding for topic data as per design `topic details sections from the deign has a top spacing that matches the height of the fixed nav-bar` 

Fixes #188 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![screenshot from 2018-08-01 12-48-55](https://user-images.githubusercontent.com/7962097/43515354-f21c9e02-958a-11e8-8503-1637595e8269.png)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation