### PR TITLE
Add missing drop statements to SQL files

### DIFF
--- a/takwimu/sql/causes_of_death_over_five.sql
+++ b/takwimu/sql/causes_of_death_over_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.causes_of_death_over_five DROP CONSTRAINT IF EXISTS pk_causes_of_death_over_five;
+DROP TABLE IF EXISTS public.causes_of_death_over_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/sql/causes_of_death_under_five.sql
+++ b/takwimu/sql/causes_of_death_under_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.causes_of_death_under_five DROP CONSTRAINT IF EXISTS pk_causes_of_death_under_five;
+DROP TABLE IF EXISTS public.causes_of_death_under_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/sql/health_centers.sql
+++ b/takwimu/sql/health_centers.sql
@@ -17,6 +17,10 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+ALTER TABLE IF EXISTS ONLY public.health_centers DROP CONSTRAINT IF EXISTS pk_health_centers;
+DROP TABLE IF EXISTS public.health_centers;
+SET default_tablespace = '';
+
 SET default_with_oids = false;
 
 --

--- a/takwimu/sql/health_centers.sql
+++ b/takwimu/sql/health_centers.sql
@@ -7,15 +7,11 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
-
-SET default_tablespace = '';
 
 ALTER TABLE IF EXISTS ONLY public.health_centers DROP CONSTRAINT IF EXISTS pk_health_centers;
 DROP TABLE IF EXISTS public.health_centers;

--- a/takwimu/sql/health_centers_ownership.sql
+++ b/takwimu/sql/health_centers_ownership.sql
@@ -17,6 +17,9 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+ALTER TABLE IF EXISTS ONLY public.health_centers_ownership DROP CONSTRAINT IF EXISTS pk_health_centers_ownership;
+DROP TABLE IF EXISTS public.health_centers_ownership;
+
 SET default_with_oids = false;
 
 --

--- a/takwimu/sql/health_centers_ownership.sql
+++ b/takwimu/sql/health_centers_ownership.sql
@@ -7,20 +7,18 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
-
-SET default_tablespace = '';
 
 ALTER TABLE IF EXISTS ONLY public.health_centers_ownership DROP CONSTRAINT IF EXISTS pk_health_centers_ownership;
 DROP TABLE IF EXISTS public.health_centers_ownership;
+SET default_tablespace = '';
 
 SET default_with_oids = false;
+
 
 --
 -- Name: health_centers_ownership; Type: TABLE; Schema: public; Owner: -

--- a/takwimu/sql/health_workers.sql
+++ b/takwimu/sql/health_workers.sql
@@ -5,19 +5,13 @@
 -- Dumped from database version 10.4 (Ubuntu 10.4-0ubuntu0.18.04)
 -- Dumped by pg_dump version 10.4 (Ubuntu 10.4-0ubuntu0.18.04)
 
--- Started on 2018-08-07 17:43:20 EAT
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
-
-SET default_tablespace = '';
 
 ALTER TABLE IF EXISTS ONLY public.health_workers DROP CONSTRAINT IF EXISTS pk_health_workers;
 DROP TABLE IF EXISTS public.health_workers;
@@ -25,7 +19,6 @@ SET default_tablespace = '';
 
 SET default_with_oids = false;
 
-SET default_with_oids = false;
 
 --
 -- Name: health_workers; Type: TABLE; Schema: public; Owner: -

--- a/takwimu/sql/health_workers.sql
+++ b/takwimu/sql/health_workers.sql
@@ -19,6 +19,12 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+ALTER TABLE IF EXISTS ONLY public.health_workers DROP CONSTRAINT IF EXISTS pk_health_workers;
+DROP TABLE IF EXISTS public.health_workers;
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
 SET default_with_oids = false;
 
 --

--- a/takwimu/sql/hiv_health_centers.sql
+++ b/takwimu/sql/hiv_health_centers.sql
@@ -18,6 +18,9 @@ SET row_security = off;
 
 SET default_tablespace = '';
 
+ALTER TABLE IF EXISTS ONLY public.hiv_health_centers DROP CONSTRAINT IF EXISTS pk_hiv_health_centers;
+DROP TABLE IF EXISTS public.hiv_health_centers;
+
 SET default_with_oids = false;
 
 --

--- a/takwimu/sql/hiv_health_centers.sql
+++ b/takwimu/sql/hiv_health_centers.sql
@@ -5,23 +5,20 @@
 -- Dumped from database version 10.4 (Ubuntu 10.4-0ubuntu0.18.04)
 -- Dumped by pg_dump version 10.4 (Ubuntu 10.4-0ubuntu0.18.04)
 
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
-
-SET default_tablespace = '';
 
 ALTER TABLE IF EXISTS ONLY public.hiv_health_centers DROP CONSTRAINT IF EXISTS pk_hiv_health_centers;
 DROP TABLE IF EXISTS public.hiv_health_centers;
+SET default_tablespace = '';
 
 SET default_with_oids = false;
+
 
 --
 -- Name: hiv_health_centers; Type: TABLE; Schema: public; Owner: -

--- a/takwimu/sql/inpatient_diagnosis_over_five.sql
+++ b/takwimu/sql/inpatient_diagnosis_over_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.inpatient_diagnosis_over_five DROP CONSTRAINT IF EXISTS pk_inpatient_diagnosis_over_five;
+DROP TABLE IF EXISTS public.inpatient_diagnosis_over_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/sql/inpatient_diagnosis_under_five.sql
+++ b/takwimu/sql/inpatient_diagnosis_under_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.inpatient_diagnosis_under_five DROP CONSTRAINT IF EXISTS pk_inpatient_diagnosis_under_five;
+DROP TABLE IF EXISTS public.inpatient_diagnosis_under_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/sql/outpatient_diagnosis_over_five.sql
+++ b/takwimu/sql/outpatient_diagnosis_over_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.outpatient_diagnosis_over_five DROP CONSTRAINT IF EXISTS pk_outpatient_diagnosis_over_five;
+DROP TABLE IF EXISTS public.outpatient_diagnosis_over_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/sql/outpatient_diagnosis_under_five.sql
+++ b/takwimu/sql/outpatient_diagnosis_under_five.sql
@@ -7,14 +7,14 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.outpatient_diagnosis_under_five DROP CONSTRAINT IF EXISTS pk_outpatient_diagnosis_under_five;
+DROP TABLE IF EXISTS public.outpatient_diagnosis_under_five;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -109,13 +109,13 @@
             <div class="column-third" id="chart-pie-health_centers-health_centers_ownership_dist" data-initial-sort="-value" data-stat-type="scaled-percentage" data-initial-sort="-value" data-chart-title="Ownership"></div>
             {% endif %}
           </section>
+          {% if not health_centers.health_centers_dist.is_missing %}
           <section class="clearfix stat-row">
-            {% if not health_centers.health_centers_dist.is_missing %}
             <div class="column-full">
               <div id="chart-histogram-health_centers-health_centers_dist" data-stat-type="scaled-percentage" data-chart-title="Number of health centers by types (2014)"></div>
             </div>
-            {% endif %}
-        </section>
+          </section>
+          {% endif %}
         </div>
       </article>
       {% endif %}


### PR DESCRIPTION
## Description

Some SQL files did not have `DROP` statements before `CREATE TABLE` statements causing errors/warning when executed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation