### PR TITLE
Overide HURUmap tagline and description.

### DIFF
--- a/takwimu/settings.py
+++ b/takwimu/settings.py
@@ -39,6 +39,9 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 HURUMAP['name'] = 'Takwimu'
 HURUMAP['url'] = os.environ.get('HURUMAP_URL','https://dev.takwimu.africa')
 
+HURUMAP['title_tagline'] = ''
+HURUMAP['description'] = ''
+
 hurumap_profile = 'census'
 
 HURUMAP['profile_builder'] = 'takwimu.profiles.{}.get_profile'.format(hurumap_profile)

--- a/takwimu/templates/profile/profile_detail.html
+++ b/takwimu/templates/profile/profile_detail.html
@@ -1,11 +1,17 @@
 {% extends 'profile/profile_detail.html' %}
 {% load staticfiles sass_tags %}
 
+{# HEAD #}
+
+{% block head_meta_description %}{{ HURUmap.description }}{% endblock %}
+
 {% block head_css %}
   {{ block.super }}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/bootstrap@4.1.1/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{% sass_src 'css/takwimu.scss' %}">
 {% endblock %}
+
+{# BODY #}
 
 {% block header %}
   {# Navbar #}


### PR DESCRIPTION
## Description

Takwimu had not set it's own tagline and description and hence the default HURUmap/Wazimap values were used.

Fixes #341 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Screenshots

### Before

![before](https://user-images.githubusercontent.com/1779590/44086318-d2aac848-9fc4-11e8-9a14-f1fda79980be.png)

### After
![after](https://user-images.githubusercontent.com/1779590/44086328-dc1f4322-9fc4-11e8-93e3-5a3a9bc7aeed.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation