### PR TITLE
Remove SQL features incompatible with PG 9.5

### DIFF
--- a/takwimu/sql/wazimap_geography.sql
+++ b/takwimu/sql/wazimap_geography.sql
@@ -50,7 +50,6 @@ CREATE TABLE public.wazimap_geography (
 --
 
 CREATE SEQUENCE public.wazimap_geography_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE


### PR DESCRIPTION
## Description

Dump was created from PG 10 which uses the optional clause `AS <data_type>` in the `CREATE SEQUENCE` that is not supported in PG 9.5 (used by `docker-compose`) causing sql migration errors.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation