### PR TITLE
Force pip to install wazimap from Github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ gunicorn==19.8.1
 
 git+https://github.com/CodeForAfrica/HURUmap.git@master#egg=hurumap
 
-# workaround: setup keeps installing wazimap from PYPI
-git+https://github.com/CodeForAfricaLabs/wazimap.git@master#egg=wazimap
+# workaround: `pip install` keeps installing wazimap from PYPI, we need the one from Github
+git+https://github.com/OpenUpSA/wazimap.git@2cdc95447c95f20d1ba9bb2e272eef25075e14ff#egg=wazimap
 
 git+https://github.com/CodeForAfricaLabs/wbdata.git@dev#egg=wbdata
 
@@ -16,4 +16,3 @@ django-debug-toolbar
 elasticsearch==5.5.3
 
 requests-aws4auth==0.9
-


### PR DESCRIPTION
## Description

`pip` doesn't process `dependency_links` in `setup.py` by default. One needs to pass `--process-dependency-links` as part of `pip install` arguments. However, this has also been deprecated, see: [this issue](https://github.com/pypa/pip/issues/4187)

Hence the need to add a direct link to @OpenUpSA/wazimap in `requrements.txt`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation