### PR TITLE
Rename the misspelled low_birth_weights column

### DIFF
--- a/takwimu/sql/child_births_with_low_birth_weights.sql
+++ b/takwimu/sql/child_births_with_low_birth_weights.sql
@@ -83,7 +83,7 @@ level1	NG_1_031	2009	low birth weights	3
 --
 
 ALTER TABLE ONLY child_births_with_low_birth_weights
-    ADD CONSTRAINT pk_child_births_with_low_birth_weights PRIMARY KEY (geo_level, geo_code, geo_version, ow_birth_weights);
+    ADD CONSTRAINT pk_child_births_with_low_birth_weights PRIMARY KEY (geo_level, geo_code, geo_version, low_birth_weights);
 
 
 --


### PR DESCRIPTION
## Description

Rename the misspelled low_birth_weights column

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation