### PR TITLE
Give each HURUmap Widget unique id

### DIFF
--- a/takwimu/templates/takwimu/_includes/dataview/hurumap.html
+++ b/takwimu/templates/takwimu/_includes/dataview/hurumap.html
@@ -1,6 +1,7 @@
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags datastructuretags %}
 
-<iframe id="cr-embed-{{id}}"
+{% uuid as id %}
+<iframe id="huru-embed-{{id}}"
         class="census-reporter-embed"
         frameborder="0"
         width="100%"
@@ -88,7 +89,7 @@
         return embed;
     }
 
-    var chart = document.getElementById('cr-embed-{{id}}');
+    var chart = document.getElementById('huru-embed-{{id}}');
     chart.addEventListener("load", function () {
         window.CensusReporterEmbeds = makeCensusEmbeds();
     });

--- a/takwimu/templatetags/datastructuretags.py
+++ b/takwimu/templatetags/datastructuretags.py
@@ -1,3 +1,4 @@
+import uuid
 from django import template
 from django.template import Variable, VariableDoesNotExist
 
@@ -6,6 +7,10 @@ register = template.Library()
 @register.simple_tag
 def to_list(*args):
     return args
+
+@register.simple_tag(name='uuid')
+def next_uuid():
+    return uuid.uuid4()
 
 @register.filter
 def object_value(obj, attr):


### PR DESCRIPTION
## Description

Since there could be more than one HURUmap Widget on a page, use UUID to
ensure each widget has a unique id.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation