### PR TITLE
[Hotfix] Indicator/widget Ids Clash

### DIFF
--- a/takwimu/templates/takwimu/_includes/dataview/indicator.html
+++ b/takwimu/templates/takwimu/_includes/dataview/indicator.html
@@ -28,8 +28,8 @@
     <ul class="nav nav-tabs justify-content-end pr-4" role="tablist">
       {% for widget in indicator.value.widgets %}
         <li class="nav-item">
-          <a class="nav-link mr-1 {% if forloop.first %} active {% endif %}" id="d{{ widget.value.title|slugify }}-dv-chart-tab" data-toggle="tab" href="#d{{ widget.value.title|slugify }}-tab" role="tab"
-             aria-controls="d{{ widget.value.title|slugify }}-tab" aria-selected="true">{% firstof widget.value.label widget.block_type|upper %}</a>
+          <a class="nav-link mr-1 {% if forloop.first %} active {% endif %}" id="{{ indicator.id }}-{{ widget.id }}-dv-chart-tab" data-toggle="tab" href="#{{ indicator.id }}-{{ widget.id }}-tab" role="tab"
+             aria-controls="{{ indicator.id }}-{{ widget.id }}-tab" aria-selected="true">{% firstof widget.value.label widget.block_type|upper %}</a>
         </li>
       {% endfor %}
     </ul>
@@ -38,8 +38,8 @@
 
       {% for widget in indicator.value.widgets %}
         <div class="tab-pane fade {% if forloop.first %} active show {% endif %}"
-             id="d{{ widget.value.title|slugify }}-tab" role="tabpanel"
-             aria-labelledby="d{{ widget.value.title|slugify }}-tab-btn">
+             id="{{ indicator.id }}-{{ widget.id }}-tab" role="tabpanel"
+             aria-labelledby="{{ indicator.id }}-{{ widget.id }}-tab-btn">
           {% include_block widget %}
         </div>
       {% endfor %}

--- a/takwimu/templates/takwimu/_includes/profile/topic_detail.html
+++ b/takwimu/templates/takwimu/_includes/profile/topic_detail.html
@@ -8,10 +8,11 @@
         <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist"
              aria-orientation="vertical">
           {% for indicator in topic.value.indicators %}
+            
             <a class="nav-link pl-5 py-3 d-flex align-items-center {% if forloop.first %} active show {% endif %}"
-               id="d{{ indicator.value.title|slugify }}-tab-btn"
-               data-toggle="pill" href="#d{{ indicator.value.title|slugify }}-tab"
-               role="tab" aria-controls="d{{ indicator.value.title|slugify }}-tab"
+               id="{{ indicator.id }}-tab-btn"
+               data-toggle="pill" href="#{{ indicator.id }}-tab"
+               role="tab" aria-controls="{{ indicator.id }}-tab"
                 {% if forloop.first %} aria-selected="true" {% endif %}
                aria-selected="false">
               <i class="fas fa-eye fa-fw"></i>
@@ -62,8 +63,8 @@
         <div class="indicators-container">
           {% for indicator in topic.value.indicators %}
             <div class="tab-pane fade {% if forloop.first %} active show {% endif %}"
-                id="d{{ indicator.value.title|slugify }}-tab" role="tabpanel"
-                aria-labelledby="d{{ indicator.value.title|slugify }}-tab-panel">
+                id="{{ indicator.id }}-tab" role="tabpanel"
+                aria-labelledby="{{ indicator.id }}-tab-panel">
             {% include 'takwimu/_includes/dataview/indicator.html' with indicator=indicator %}
             </div>
           {% endfor %}


### PR DESCRIPTION
## Description

Use `indicator.id` or `widget.id` instead of slugifying titles that may clash or even be absent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation