### PR TITLE
Fix multiple HURUmap widgets on a single page

### DIFF
--- a/takwimu/templates/takwimu/_includes/dataview/hurumap.html
+++ b/takwimu/templates/takwimu/_includes/dataview/hurumap.html
@@ -21,13 +21,15 @@
 </style>
 
 <script>
-    function makeCensusEmbeds() {
+
+    // Work with a single iframe at a time
+    function makeCensusEmbeds(selectors) {
         var embed = {
             embeds: {}
         };
 
         embed.init = function () {
-            embed.containers = document.querySelectorAll('.census-reporter-embed');
+            embed.containers = document.querySelectorAll(selectors);
             embed.numContainers = embed.containers.length;
             for (var i = 0; i < embed.numContainers; i++) {
                 embed.embeds[embed.containers[i].id] = {
@@ -103,8 +105,31 @@
         return embed;
     }
 
+    // Create viz for all visible iframes
     var addEmbeds = function addEmbeds() {
-        window.CensusReporterEmbeds = makeCensusEmbeds();
+        this.contentWindow.CensusReporterEmbeds = makeCensusEmbeds('#cr-embed-country-{{value.data_country}}-{{value.data_id}}');
     }
-    window.addEventListener('load', addEmbeds);
+    var viz = document.getElementById('cr-embed-country-{{value.data_country}}-{{value.data_id}}');
+    viz.addEventListener('load', addEmbeds);
+
+    window.addEventListener('load', function() {
+
+        // For all widgets in hidden tabs (on single indicator),
+        // create them when they're shown
+        $('.indicator .nav-link').on('shown.bs.tab', function(e) {
+            widgetId = e.target.getAttribute('href');
+            $(widgetId + ' .census-reporter-embed').each(function(){
+                this.contentWindow.CensusReporterEmbeds = makeCensusEmbeds('#' + this.id);
+            });
+        });
+
+        // For the active widget on a hidden indicator,
+        // create it when the indicator is shown
+        $('.dataindicators-nav .nav-link').on('shown.bs.tab', function(e) {
+            indicatortId = e.target.getAttribute('href');
+            $(indicatortId + ' .tab-pane.active .census-reporter-embed').each(function() {
+                this.contentWindow.CensusReporterEmbeds = makeCensusEmbeds('#' + this.id);
+            });
+        });
+    });
 </script>


### PR DESCRIPTION
## Description
HURUmap widgets couldn't be shown on the same page because the script wanted to process all of them at the same time.This only works on those cases where some are not hidden as in hidden tabs.

This is fixed by making the script capable of process a single iframe at a time as well as adding listeners for when inactive tabs on widgets and indicators are activated.

Fixes #403 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![peek 2018-09-27 16-49](https://user-images.githubusercontent.com/1779590/46151198-ef35a580-c276-11e8-952b-92767a44f005.gif)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation