### PR TITLE
[Hotfix] Ignore any found boto.cfg file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - pip install -r requirements.txt
 
 before_script:
+  - export BOTO_CONFIG=/dev/null
   - psql -c "create user takwimu with password 'takwimu';" -U postgres
   - psql -c 'create database test_takwimu;' -U postgres
   - psql -c 'alter database test_takwimu owner to takwimu;' -U postgres


### PR DESCRIPTION
## Description

From https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-310759657:

Yeah so this happens because of the /etc/boto.cfg file which (I believe) Google adds to their system images - the idea being that it loads some plugins that let you use boto more easily with Google Cloud services. This is mostly useless in a CI environment though. If you look at the config file, you'll see that it tries to load a Python plugin, which the travis people must have somehow corrupted in this image. It is unfortunate that they switched to a new image without testing widely used libraries like `boto`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation