### PR TITLE
[Hotfix] Travis uses outdated `requests` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
 install:
 
   - pip install -r requirements.txt
+  - pip install requests==2.19.1
 
 before_script:
   - sudo rm -f /etc/boto.cfg


### PR DESCRIPTION
## Description

Travis throws `ImportError: cannot import name certs`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![screenshot from 2018-10-17 18-19-35](https://user-images.githubusercontent.com/1779590/47097125-67b9d180-d239-11e8-967d-1e96e7d37495.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation