### PR TITLE
Bandage for Requests/Urllib3 incompatiblity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ services:
 install:
 
   - pip install -r requirements.txt
-  - pip install requests==2.19.1
 
 before_script:
   - sudo rm -f /etc/boto.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ requests-aws4auth==0.9
 psycopg2-binary==2.7.5
 django-redis==4.9.0
 
+# Work around for incompatibility between requests & urllib3
+urllib3==1.23
+
 # Workaround for dependency links
 # Comment out when changes / updates / PR accepted
 git+https://github.com/CodeForAfricaLabs/wazimap.git@master#egg=wazimap


### PR DESCRIPTION
## Description

`urllib3` released `v1.24` yesterday which breaks `requests` causing deployment failures.

See:

 + https://github.com/urllib3/urllib3/issues/1459
 + https://github.com/requests/requests/issues/4830        

Solution: Pin `urllib3`  to `v1.23` until resolved upstream

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation