### PR TITLE
[Feature] Use database caching instead of Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   db:
@@ -18,11 +18,6 @@ services:
     environment:
       ES_JAVA_OPTS: -Xms512m -Xmx512m
 
-  redis:
-    image: redis
-    ports:
-      - "6379:6379"
-
   web:
     build: .
     ports:
@@ -30,7 +25,6 @@ services:
     depends_on:
       - db
       - es
-      - redis
     volumes:
       - "./:/srv/takwimu"
     environment:
@@ -44,8 +38,8 @@ services:
       - TAKWIMU_ES_INDEX=takwimu
       - TAKWIMU_ES_TIMEOUT=30
       - TAKWIMU_ES_URL=http://es:9200
-      - TAKWIMU_CACHE=${TAKWIMU_CACHE}
-      - TAKWIMU_CACHE_URL=reddis://redis:6379
-      - TAKWIMU_CACHE_KEY_PREFIX="takwimu"
+      - TAKWIMU_CACHE=True
+      - TAKWIMU_CACHE_LOCATION=takwimu_cache
+      - TAKWIMU_CACHE_KEY_PREFIX=takwimu
       - PYTHONDONTWRITEBYTECODE="True"
       # - DJANGO_DEBUG=False  # For testing deploys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,31 @@ services:
       - TAKWIMU_ES_INDEX=takwimu
       - TAKWIMU_ES_TIMEOUT=30
       - TAKWIMU_ES_URL=http://es:9200
+      - PYTHONDONTWRITEBYTECODE="True"
+  
+  # Test production configuration
+  test-prod:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - es
+    volumes:
+      - "./:/srv/takwimu"
+    environment:
+      - DATABASE_URL=postgresql://takwimu:takwimu@db:5432/takwimu
+      - DJANGO_SECRET_KEY=somethingsecret
+      - HURUMAP_URL=http://localhost:8000
+      - PGHOST=db
+      - PGDATABASE=takwimu
+      - PGUSER=takwimu
+      - PGPASSWORD=takwimu
+      - TAKWIMU_ES_INDEX=takwimu
+      - TAKWIMU_ES_TIMEOUT=30
+      - TAKWIMU_ES_URL=http://es:9200
       - TAKWIMU_CACHE=True
       - TAKWIMU_CACHE_LOCATION=takwimu_cache
       - TAKWIMU_CACHE_KEY_PREFIX=takwimu
       - PYTHONDONTWRITEBYTECODE="True"
-      # - DJANGO_DEBUG=False  # For testing deploys
+      # - DJANGO_DEBUG=False  # TODO: Figure out media + static

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,7 @@ cat takwimu/sql/*.sql | psql              # Upload tables / data
 python manage.py compilescss              # Compile SCSS (offline)
 python manage.py collectstatic --noinput  # Collect static files
 python manage.py update_index             # Update search index
+python manage.py createcachetable         # Create CACHE table
 
 # Prepare log files and start outputting logs to stdout
 touch /srv/logs/gunicorn.log

--- a/takwimu/settings.py
+++ b/takwimu/settings.py
@@ -11,18 +11,19 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # insert our overrides before both census and hurumap
 
-INSTALLED_APPS = ['takwimu', 'wagtail.contrib.modeladmin', 'fontawesome', 'wagtail.contrib.settings'] + INSTALLED_APPS + ['debug_toolbar']
+INSTALLED_APPS = ['takwimu', 'wagtail.contrib.modeladmin', 'fontawesome',
+                  'wagtail.contrib.settings'] + INSTALLED_APPS + ['debug_toolbar']
 
 
 ROOT_URLCONF = 'takwimu.urls'
 
 MIDDLEWARE_CLASSES = (
-        'whitenoise.middleware.WhiteNoiseMiddleware',
-        'django.middleware.cache.FetchFromCacheMiddleware',
-        'django.middleware.cache.UpdateCacheMiddleware',
-    ) + MIDDLEWARE_CLASSES + (
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    )
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
+    'django.middleware.cache.UpdateCacheMiddleware',
+) + MIDDLEWARE_CLASSES + (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
 
 INTERNAL_IPS = ['127.0.0.1', '172.18.0.1']
 
@@ -47,14 +48,15 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 # -------------------------------------------------------------------------------------
 
 HURUMAP['name'] = 'Takwimu'
-HURUMAP['url'] = os.environ.get('HURUMAP_URL','https://dev.takwimu.africa')
+HURUMAP['url'] = os.environ.get('HURUMAP_URL', 'https://dev.takwimu.africa')
 
 HURUMAP['title_tagline'] = ''
 HURUMAP['description'] = ''
 
 hurumap_profile = 'census'
 
-HURUMAP['profile_builder'] = 'takwimu.profiles.{}.get_profile'.format(hurumap_profile)
+HURUMAP['profile_builder'] = 'takwimu.profiles.{}.get_profile'.format(
+    hurumap_profile)
 HURUMAP['default_geo_version'] = os.environ.get('DEFAULT_GEO_VERSION', '2009')
 HURUMAP['legacy_embed_geo_version'] = '2009'
 
@@ -133,7 +135,8 @@ TAKWIMU_ES_HOST_TYPE = os.environ.get('TAKWIMU_ES_HOST_TYPE', '')
 if TAKWIMU_ES_HOST_TYPE.lower() == 'aws':
     TAKWIMU_ES_AWS_ACCESS_KEY = os.environ.get('TAKWIMU_ES_AWS_ACCESS_KEY', '')
     TAKWIMU_ES_AWS_SECRET_KEY = os.environ.get('TAKWIMU_ES_AWS_SECRET_KEY', '')
-    TAKWIMU_ES_AWS_REGION = os.environ.get('TAKWIMU_ES_AWS_REGION', 'eu-west-1')
+    TAKWIMU_ES_AWS_REGION = os.environ.get(
+        'TAKWIMU_ES_AWS_REGION', 'eu-west-1')
     WAGTAILSEARCH_BACKENDS = {
         'default': {
             'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch5',
@@ -171,15 +174,14 @@ else:
 TAKWIMU_CACHE = os.environ.get('TAKWIMU_CACHE', '')
 
 if TAKWIMU_CACHE:
-    TAKWIMU_CACHE_URL = os.environ.get('TAKWIMU_CACHE_URL', '127.0.0.1:6379')
-    TAKWIMU_CACHE_KEY_PREFIX = os.environ.get('TAKWIMU_CACHE_KEY', 'takwimu')
+    TAKWIMU_CACHE_LOCATION = os.environ.get(
+        'TAKWIMU_CACHE_LOCATION', 'takwimu_cache')
+    TAKWIMU_CACHE_KEY_PREFIX = os.environ.get(
+        'TAKWIMU_CACHE_KEY_PREFIX', 'takwimu')
     CACHES = {
         'default': {
-            'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION': TAKWIMU_CACHE_URL,
-            'OPTIONS': {
-                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            },
-            "KEY_PREFIX": TAKWIMU_CACHE_KEY_PREFIX,
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': TAKWIMU_CACHE_LOCATION,
+            'KEY_PREFIX': TAKWIMU_CACHE_KEY_PREFIX,
         }
     }


### PR DESCRIPTION
## Description

To reduce the DevOps work of managing yet another instance, we will start with database caching for now while Takwimu still has low volume. Should the need arise in the future, the topic of which caching is best for Takwimu will discussed again.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation