### PR TITLE
162008192 Multi Field Search Support

### DIFF
--- a/takwimu/management/commands/update_topics_index.py
+++ b/takwimu/management/commands/update_topics_index.py
@@ -24,17 +24,20 @@ class Command(BaseCommand):
 
             for topic in i.body.stream_data:
                 topic_id = topic['id']
+                title = topic['value'].get('title', '')
                 topic_body = topic['value'].get('body', '')
                 topic_summary = topic['value'].get('summary', '')
                 body = '\n'.join([topic_summary, topic_body])
 
-                _, outcome = search_backend.add_to_index(category,
-                                                         body,
+                _, outcome = search_backend.add_to_index(topic_id,
+                                                         'topic',
                                                          country,
+                                                         category,
+                                                         title,
+                                                         body,
                                                          parent_page_id,
                                                          parent_page_type,
-                                                         topic_id,
-                                                         'topic')
+                                                         )
                 self.stdout.write(
                     search_backend.es_index + ": Indexing topic '%s result %s'" % (
                         topic_id,
@@ -47,15 +50,17 @@ class Command(BaseCommand):
                         data = get_widget_data(widget)
                         if data:
                             _, outcome = search_backend.add_to_index(
-                                category,
-                                data['body'],
+                                data['id'],
+                                'indicator_widget',
                                 country,
+                                category,
+                                data['title'],
+                                data['body'],
                                 parent_page_id,
-                                parent_page_type,
-                                data['widget_id'],
-                                'indicator_widget')
+                                parent_page_type
+                            )
                             self.stdout.write(
                                 search_backend.es_index + ": Indexing widget '%s result %s'" % (
-                                    data['widget_id'],
+                                    data['id'],
                                     outcome,
                                 ))

--- a/takwimu/search/takwimu_search.py
+++ b/takwimu/search/takwimu_search.py
@@ -17,7 +17,12 @@ DOC_TYPE = 'topic'
 #      all others,
 #  ii) relevant `category` should be preferred over irrevant one, and
 # iii) matching `title` should be given more weight than just matching `body`.
-QUERY_FIELDS = ['country^3', 'category^2', 'title^2', 'body']
+QUERY_FIELDS = [
+    'country^' + settings.TAKWIMU_ES_FIELDS_COUNTRY_BOOST,
+    'category^' + settings.TAKWIMU_ES_FIELDS_CATEGORY_BOOST,
+    'title^' + settings.TAKWIMU_ES_FIELDS_TITLE_BOOST,
+    'body^' + settings.TAKWIMU_ES_FIELDS_BODY_BOOST,
+]
 
 
 def tagify(phrase):

--- a/takwimu/search/utils.py
+++ b/takwimu/search/utils.py
@@ -32,8 +32,9 @@ def get_widget_data(widget):
             body = '\n\n'.join([body, entity_content])
 
     return {
-        'widget_id': widget_id,
-        'body': '\n'.join([title, body, source]),
+        'id': widget_id,
+        'title': title,
+        'body': '\n'.join([body, source]),
     }
 
 

--- a/takwimu/settings.py
+++ b/takwimu/settings.py
@@ -168,8 +168,14 @@ TAKWIMU_ES_INDEX_SETTINGS = {
         }
     }
 }
-
-
+TAKWIMU_ES_FIELDS_COUNTRY_BOOST = os.environ.get(
+    'TAKWIMU_ES_FIELDS_COUNTRY_BOOST', '4')
+TAKWIMU_ES_FIELDS_CATEGORY_BOOST = os.environ.get(
+    'TAKWIMU_ES_FIELDS_CATEGORY_BOOST', '3')
+TAKWIMU_ES_FIELDS_TITLE_BOOST = os.environ.get(
+    'TAKWIMU_ES_FIELDS_TITLE_BOOST', '2')
+TAKWIMU_ES_FIELDS_BODY_BOOST = os.environ.get(
+    'TAKWIMU_ES_FIELDS_BODY_BOOST', '1')
 TAKWIMU_ES_INDEX = os.environ.get('TAKWIMU_ES_INDEX', 'takwimu-dev')
 TAKWIMU_ES_TIMEOUT = int(os.environ.get('TAKWIMU_ES_TIMEOUT', '30'))
 TAKWIMU_ES_URL = os.environ.get('TAKWIMU_ES_URL', 'http://localhost:9200')

--- a/takwimu/signals.py
+++ b/takwimu/signals.py
@@ -27,17 +27,19 @@ def index_new_changes_in_profilepage(sender, instance, created, **kwargs):
     parent_page_id = instance.id
     for topic in instance.body.stream_data:
         topic_id = topic.get('id')
+        title = topic['value'].get('title', '')
         topic_body = topic['value'].get('body', '')
         topic_summary = topic['value'].get('summary', '')
         body = topic_body + " " + topic_summary
 
-        result, outcome = search_backend.add_to_index(category,
-                                                      body,
+        result, outcome = search_backend.add_to_index(topic_id,
+                                                      'topic',
                                                       country,
+                                                      category,
+                                                      title,
+                                                      body,
                                                       parent_page_id,
-                                                      parent_page_type,
-                                                      type="topic",
-                                                      topic_id=topic_id)
+                                                      parent_page_type)
 
         indicators = topic['value'].get('indicators', '')
         for indicator in indicators:
@@ -45,11 +47,12 @@ def index_new_changes_in_profilepage(sender, instance, created, **kwargs):
                 data = get_widget_data(widget)
                 if data:
                     result, outcome = search_backend.add_to_index(
-                        category,
-                        data.get('body'),
+                        data['id'],
+                        'indicator_widget',
                         country,
+                        category,
+                        data['title'],
+                        data['body'],
                         parent_page_id,
-                        parent_page_type,
-                        type='indicator_widget',
-                        widget_id=data.get(
-                            'widget_id'))
+                        parent_page_type
+                    )

--- a/takwimu/templates/takwimu/_includes/search/table.html
+++ b/takwimu/templates/takwimu/_includes/search/table.html
@@ -42,11 +42,11 @@
             <td class="text-capitalize px-0 align-middle" style="white-space:nowrap">
                 <span class="d-flex mb-2">
                     <b class="col-5">Country:</b>
-                    <span class="col pl-3">{{ result.country|slugify }}</span>
+                    <span class="col pl-3">{{ result.country }}</span>
                 </span>
                 <span class="d-flex justify-content-center">
                     <b class="col-5">Region:</b>
-                    <span class="col pl-3">{{ result.region|slugify }}</span>
+                    <span class="col pl-3">{{ result.region }}</span>
                 </span>
             </td>
             <td colspan="2" class="text-capitalize px-0 data" style="white-space:wrap;">


### PR DESCRIPTION
## Description

Concatenating everything into a single field does not work well for cases where different fields should carry different weight. For example:

    1. kenya medical: Here, results from Kenya with medical (or similar terms) should be prioritised over results from other countries even if those other countries have exact medical matching indicators.

    2. policy gender: Since there are policy specific categories, indicators matching gender should be prioritised over other categories.

The key issue here is adding multi field search with tunable weights (in settings.py) with good enough defaults.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots

New search on the right shows how emphasis can be given to country, and title over body content.

![takwimu-search-comparison](https://user-images.githubusercontent.com/1779590/48623033-9c948200-e9b9-11e8-9275-aadc301eef9d.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation