### PR TITLE
Make space for Takwimu logo on Navbar [162169812]

### DIFF
--- a/takwimu/templates/takwimu/_includes/homepage/hero.html
+++ b/takwimu/templates/takwimu/_includes/homepage/hero.html
@@ -29,7 +29,7 @@
 
         <div class="col-md-6 col-lg-4">
           <div id="carousel-homepage-hero"
-               data-ride="carousel"
+               data-toggle="carousel"
                class="carousel slide bg-info shaddow"
                style="height: 425px">
             <ol class="carousel-indicators">

--- a/takwimu/templates/takwimu/_layouts/_base.html
+++ b/takwimu/templates/takwimu/_layouts/_base.html
@@ -26,7 +26,7 @@
   {% endblock %}
 
   {% block head_css %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/bootstrap@4.1.1/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/bootstrap@4.1.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="{% sass_src 'css/takwimu.scss' %}">
   {% endblock %}
 
@@ -54,6 +54,7 @@
   <script src="{% static 'js/plugins.js' %}"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha256-98vAGjEDGN79TjHkYWVD4s87rvWkdWLHPs5MC3FvFX4=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha256-VsEqElsCHSGmnmHXGQzvoWjWwoznFSZc6hs7ARLRacQ=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha256-xaF9RpdtRxzwYMWg4ldJoyPWqyDPCRD0Cv7YEEe6Ie8=" crossorigin="anonymous"></script>
   <script src="{% static 'js/main.js' %}"></script>
   <script src="{% static 'js/svg.js' %}"></script>
@@ -77,7 +78,7 @@
 
   <!-- Enable Plugins -->
   <script type="text/javascript">
-    // Bootstrap: Enable Tooltips, Popovers
+    // Bootstrap: Enable Tooltips, Popovers, Carousel
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();
       $('[data-toggle="popover"]').popover({
@@ -89,7 +90,8 @@
               $popup.popover('hide');
           });
       });
-      
+      $('[data-toggle="carousel"]').carousel();
+
       // Anchors: Enable Anchors
       anchors.options = {
         icon: '#'


### PR DESCRIPTION
## Description

Remove unnecessary social media icons from Navbar to make a little extra room for Takwimu logo.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

### Current Navbar

![screenshot from 2018-11-23 16-46-43](https://user-images.githubusercontent.com/1779590/48947668-f4dffc80-ef42-11e8-916a-c26a546a2b81.png)

### Fixed Navbar

![screenshot from 2018-11-23 17-13-01](https://user-images.githubusercontent.com/1779590/48947733-2c4ea900-ef43-11e8-8450-82c84ff9db56.png)

### Fixed homepage script initialization error.

![screenshot from 2018-11-23 17-04-38](https://user-images.githubusercontent.com/1779590/48947675-fa3d4700-ef42-11e8-834f-a7114f831b1f.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas