### PR TITLE
Use default tracker to send selection/copy events [Hotfix]

### DIFF
--- a/takwimu/templates/takwimu/profile_page.html
+++ b/takwimu/templates/takwimu/profile_page.html
@@ -116,7 +116,7 @@
 
     var trackEvent = function trackEvent(category, event, target) {
       if (window.ga) {
-        window.ga('t1.send', 'event', category, event, target);
+        window.ga('send', 'event', category, event, target);
       }
     };
 


### PR DESCRIPTION
## Description

Events were being sent using secondary trackers instead of the default Takwimu tracker.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas