### PR TITLE
Use Wazimap/HURUmap releases [Hotfix]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn==19.9.0
 
-git+https://github.com/CodeForAfrica/HURUmap.git@v0.0.1#egg=hurumap
+git+https://github.com/CodeForAfrica/HURUmap.git@0.0.13#egg=hurumap
 
 git+https://github.com/CodeForAfricaLabs/wbdata.git@dev#egg=wbdata
 
@@ -18,4 +18,4 @@ psycopg2-binary==2.7.5
 
 # Workaround for dependency links
 # Comment out when changes / updates / PR accepted
-git+https://github.com/CodeForAfricaLabs/wazimap.git@master#egg=wazimap
+git+https://github.com/CodeForAfricaLabs/wazimap.git@0.0.1#egg=wazimap


### PR DESCRIPTION
## Description

Use [CodeForAfricaLabs/Wazimap](https://github.com/CodeForAfricaLabs/Wazimap/releases) & [CodeForAfrica/HURUmap](https://github.com/CodeForAfrica/HURUmap/releases)  releases instead of `master` branch

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas