### PR TITLE
Load Medium posts from URL provided in SocialMediaSettings

### DIFF
--- a/takwimu/context_processors.py
+++ b/takwimu/context_processors.py
@@ -7,7 +7,8 @@ from takwimu import settings
 from takwimu.utils.helpers import get_takwimu_stories, get_takwimu_countries
 from takwimu.utils.medium import Medium
 
-from takwimu.models.dashboard import ProfilePage, ProfileSectionPage, CountryProfilesSetting
+from takwimu.models.dashboard import ProfilePage, ProfileSectionPage, \
+    CountryProfilesSetting, SocialMediaSetting
 from takwimu.models.dashboard import TopicPage
 
 from .sdg import SDG
@@ -15,12 +16,12 @@ from .sdg import SDG
 
 def takwimu_countries(request):
     country_profile_settings = CountryProfilesSetting.for_site(request.site)
-    published_status = country_profile_settings.__dict__
-    return get_takwimu_countries(published_status)
+    return get_takwimu_countries(country_profile_settings.__dict__)
 
 
 def takwimu_stories(request):
-    return get_takwimu_stories()
+    social_media_settings = SocialMediaSetting.for_site(request.site)
+    return get_takwimu_stories(social_media_settings)
 
 
 def takwimu_topics(request):

--- a/takwimu/takwimu_ui/src/components/LatestNewsStories/index.js
+++ b/takwimu/takwimu_ui/src/components/LatestNewsStories/index.js
@@ -25,7 +25,9 @@ const styles = () => ({
 
 function LatestNewsStories({
   classes,
-  takwimu: { latest_news_stories: latestNewsStories, stories },
+  takwimu: {
+    latest_news_stories: { description, stories }
+  },
   width
 }) {
   const Stories = isWidthUp('md', width) ? StoryBlocks : StoryList;
@@ -41,13 +43,13 @@ function LatestNewsStories({
         alignItems="flex-start"
         className={classes.root}
       >
-        {latestNewsStories && latestNewsStories.description && (
+        {description && (
           <Grid item xs={12}>
             <Typography
               variant="body1"
               classes={{ root: classes.descriptionRoot }}
             >
-              {latestNewsStories.description}
+              {description}
             </Typography>
           </Grid>
         )}
@@ -58,7 +60,7 @@ function LatestNewsStories({
             </Button>
           </A>
         </Grid>
-        {stories && stories.length && (
+        {stories.length > 0 && (
           <Grid item xs={12}>
             <Stories stories={stories} />
           </Grid>
@@ -71,8 +73,10 @@ function LatestNewsStories({
 LatestNewsStories.propTypes = {
   classes: PropTypes.shape({}).isRequired,
   takwimu: PropTypes.shape({
-    latest_news_stories: PropTypes.shape({}).isRequired,
-    stories: PropTypes.arrayOf(PropTypes.shape({}).isRequired)
+    latest_news_stories: PropTypes.shape({
+      description: PropTypes.string.isRequired,
+      stories: PropTypes.arrayOf(PropTypes.shape({}).isRequired)
+    }).isRequired
   }).isRequired,
   width: PropTypes.string.isRequired
 };

--- a/takwimu/templates/takwimu/home_page.html
+++ b/takwimu/templates/takwimu/home_page.html
@@ -23,6 +23,5 @@
     var takwimu = window.takwimu || {};
     takwimu.page = takwimu.page || {};
     takwimu.page.id = 'homepage';
-    takwimu.stories = {{ stories_latest |jsonify|safe }};
   </script>
 {% endblock body_javascript_extra %}

--- a/takwimu/utils/helpers.py
+++ b/takwimu/utils/helpers.py
@@ -61,17 +61,17 @@ COUNTRIES['ZM'] = {
 }
 
 
-def get_takwimu_stories():
+def get_takwimu_stories(social_media_settings, return_dict=False):
     stories_latest = []
 
     try:
-        if settings.HURUMAP.get('url') != 'https://takwimu.africa':
+        if settings.HURUMAP.get('url').rstrip('/').endswith('takwimu.africa'):
+            client = Medium()
+            stories = client.get_posts(social_media_settings.medium, count=3,
+                                       return_dict=True)
+        else:
             with open('data/articles.json') as f:
                 stories = json.load(f)
-        else:
-            client = Medium()
-            stories = client.get_publication_posts('takwimu-africa',
-                                                   count=3)
 
         stories_latest = stories[0:3]
     except Exception:

--- a/takwimu/utils/medium.py
+++ b/takwimu/utils/medium.py
@@ -15,24 +15,29 @@ ESCAPE_CHARACTERS = "])}while(1);</x>"
 
 
 class Medium(object):
-    def get_publication_posts(self, publication_name, count=10):
+    def get_posts(self, url, count=10, return_dict=False):
+        return self._send_post_request(
+            "{0}/latest?limit={count}".format(url, count=count), return_dict)
+
+    def get_publication_posts(self, publication_name, count=10, return_dict=False):
         return self._send_post_request(
             BASE_PATH + "{0}/latest?limit={count}".format(publication_name,
-                                                          count=count))
+                                                          count=count), return_dict)
 
     @staticmethod
-    def _send_request(url, parse_function):
+    def _send_request(url, parse_function, return_dict):
         req = requests.get(url, headers={"Accept": "application/json"})
-        # print(url, req.status_code)
+
         if req.status_code == requests.codes.ok:
-            return parse_function(
-                json.loads(req.text.replace(ESCAPE_CHARACTERS, "").strip()))
+            payload = json.loads(req.text.replace(
+                ESCAPE_CHARACTERS, "").strip())
+            return parse_function(payload, return_dict)
         else:
             return None
 
     @staticmethod
-    def _send_post_request(url):
-        return Medium._send_request(url, Medium.parse_post)
+    def _send_post_request(url, return_dict):
+        return Medium._send_request(url, Medium.parse_post, return_dict)
 
     @staticmethod
     def parse_images(image_dict, return_dict=False):


### PR DESCRIPTION
## Description
Load Medium posts from URL provided in `SocialMediaSettings` rather than hard-coded `takwimu-africa`. Also:

 i. Load articles via API rather than templates, and
 ii. Enable loading articles from `staging.takwimu.africa`.

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

![Screenshot_2019-04-23 Takwimu](https://user-images.githubusercontent.com/1779590/56585693-05c29600-65e7-11e9-8756-d61551216d2e.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation