### PR TITLE
Fix Media URLs

### DIFF
--- a/takwimu/settings.py
+++ b/takwimu/settings.py
@@ -44,6 +44,8 @@ STATICFILES_DIRS = [
 HURUMAP['name'] = 'Takwimu'
 HURUMAP['url'] = os.environ.get('HURUMAP_URL', 'https://takwimu.africa')
 
+WAGTAILAPI_BASE_URL = HURUMAP['url']
+
 HURUMAP['title_tagline'] = ''
 HURUMAP['description'] = ''
 


### PR DESCRIPTION
## Description

PDFs were not loading they were being served over HTTP and the site over HTTPS.

Wagtail [defaults](https://github.com/wagtail/wagtail/blob/c9e740324c1a2197454274f5d18514b9a0752374/wagtail/api/v2/utils.py#L14) to the site URL if `WAGTAILAPI_BASE_URL` is not provided in the settings



Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation