### PR TITLE
[Staging] Fix search index

### DIFF
--- a/takwimu/management/commands/update_topics_index.py
+++ b/takwimu/management/commands/update_topics_index.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
                                     content_id=data['id'],
                                     content_type='indicator_widget',
                                     country=country, category=category,
-                                    title=(data['title'] or 'NULL'), body=data['body'],
+                                    title=(data['title']), body=data['body'],
                                     metadata=data['metadata'],
                                     parent_page_id=parent_page_id,
                                     parent_page_type=parent_page_type,

--- a/takwimu/search/takwimu_search.py
+++ b/takwimu/search/takwimu_search.py
@@ -283,6 +283,10 @@ class TakwimuTopicSearch():
         - parent_page_type
         :return:
         """
+        #title should not be empty as es matches title field
+        #set title to a string null if empty
+        if len(title.strip()) == 0:
+            title = "null"
 
         doc = {
             'content_id': content_id,


### PR DESCRIPTION
## Description
`update_topics_index` was failing for analysis data as some `profilesectionpage` had empty titles while es match titles. This bug is fixed by setting title to a random string `null` when it's empty.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Fix
![Screenshot from 2019-05-27 16-12-10](https://user-images.githubusercontent.com/7962097/58422453-46587800-809b-11e9-849e-569bc6b4a891.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation