### PR TITLE
[Staging] [Hotfix] Preserve ProfileData

### DIFF
--- a/takwimu/management/commands/update_topics_index.py
+++ b/takwimu/management/commands/update_topics_index.py
@@ -104,9 +104,6 @@ class Command(BaseCommand):
             # remove trailing slash
             server_url = server_url[:-1]
 
-        # clean out profleData DB
-        ProfileData.objects.all().delete()
-
         for code, detail in COUNTRIES.items():
             country = detail.get('name')
             url = f"profiles/country-{code}-{slugify(country)}"


### PR DESCRIPTION
## Description

Deleting ProfileDate before indexing means we'll be losing any summaries that have been written by content team. This is not acceptable.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation