### PR TITLE
[FIX] Flourish widget assets folder support

### DIFF
--- a/takwimu/renderers.py
+++ b/takwimu/renderers.py
@@ -10,6 +10,7 @@ class CSSRenderer(BaseRenderer):
     def render(self, data, accepted_media_type=None, renderer_context=None):
         return data
 
+
 class JavaScriptRenderer(BaseRenderer):
     media_type = "text/javascript"
     format = "js"

--- a/takwimu/urls.py
+++ b/takwimu/urls.py
@@ -44,7 +44,7 @@ takwimu_urlpatterns = [
     url(r'^api/v2/', api_router.urls),
     url(r'^flourish/(?P<document_id>\d+)/$',
         FlourishView.as_view(), name="flourish"),
-    url(r'^flourish/(?P<document_id>\d+)/(?P<filename>.+)/$',
+    url(r'^flourish/(?P<document_id>\d+)/(?P<path>.+)/$',
         FlourishView.as_view(), name="flourish_filename"),
     url(
         r'^data/(?P<format>map|table|distribution)/$',

--- a/takwimu/views.py
+++ b/takwimu/views.py
@@ -347,10 +347,10 @@ class FlourishView(APIView):
             # A request from within another file, will come as
             # 'first file/second file' to the server
             # eg. './icon.png' from 'style.css' => 'style.css/icon.png'
-            path_parts = path.split('/')
-            for index, part in enumerate(path_parts):
-                if '.' in part and index != len(path_parts) - 1:
-                    path_parts.pop(index)
+            path_parts = []
+            for index, path_part in enumerate(path.split('/')):
+                if '.' not in path_part or index == len(path_parts) - 1:
+                    path_parts.append(path_part)
 
             extract_path = "/".join(path_parts)
 
@@ -360,10 +360,13 @@ class FlourishView(APIView):
             response = requests.get(doc.file.url, stream=True)
             zip_ref = zipfile.ZipFile(io.BytesIO(response.content))
 
-        file_path = zip_ref.extract(extract_path, "/tmp/" + kwargs["document_id"])
+        file_path = zip_ref.extract(
+            extract_path, "/tmp/" + kwargs["document_id"])
         zip_ref.close()
         mode, content_type = ('r', 'text')
-        if not extract_path.split('/')[-1].endswith(('html', 'css', 'txt', 'svg')):
+        if not extract_path.split('/')[-1].endswith(
+            ('html', 'css', 'txt', 'svg')
+        ):
             mode, content_type = ('rb', 'media/*')
         return Response(open(file_path).read())
 

--- a/takwimu/views.py
+++ b/takwimu/views.py
@@ -275,7 +275,7 @@ class IndicatorsGeographyDetailView(GeographyDetailView):
         json_data = open("takwimu/fixtures/sdg.json")
         data = json.load(json_data)
 
-        ## get profileData aka summaries from wagtail
+        # get profileData aka summaries from wagtail
         summary_data = ProfileData.objects.filter(
             country_iso_code=self.geo.geo_code).values('id', 'chart_id',
                                                        'summary')
@@ -333,22 +333,26 @@ class IndicatorsGeographyDetailView(GeographyDetailView):
 
 
 class FlourishView(APIView):
-    renderer_classes = (FlourishHTMLRenderer, CSSRenderer, JavaScriptRenderer, JPEGRenderer, SVGRenderer,)
+    renderer_classes = (FlourishHTMLRenderer, CSSRenderer,
+                        JavaScriptRenderer, JPEGRenderer, SVGRenderer,)
 
     def get(self, request, *args, **kwargs):
         Document = get_document_model()
         doc = get_object_or_404(Document, id=kwargs["document_id"])
 
-        filename = "index.html"
-        if "filename" in kwargs and kwargs["filename"]:
-            filename = kwargs["filename"]
+        extract_path = "index.html"
+        if "path" in kwargs and kwargs["path"]:
+            path = kwargs["path"]
 
-        # A request from within another file, will come as
-        # 'first file/second file' to the server
-        # eg. './icon.png' from 'style.css' => 'style.css/icon.png'
-        filename_parts = filename.split('/')
-        if len(filename_parts) > 1:
-            filename = filename_parts[-1]
+            # A request from within another file, will come as
+            # 'first file/second file' to the server
+            # eg. './icon.png' from 'style.css' => 'style.css/icon.png'
+            path_parts = path.split('/')
+            for index, part in enumerate(path_parts):
+                if '.' in part and index != len(path_parts) - 1:
+                    path_parts.pop(index)
+
+            extract_path = "/".join(path_parts)
 
         try:
             zip_ref = zipfile.ZipFile(doc.file.path, "r")
@@ -356,12 +360,11 @@ class FlourishView(APIView):
             response = requests.get(doc.file.url, stream=True)
             zip_ref = zipfile.ZipFile(io.BytesIO(response.content))
 
-        file_path = zip_ref.extract(filename, "/tmp/" + kwargs["document_id"])
+        file_path = zip_ref.extract(extract_path, "/tmp/" + kwargs["document_id"])
         zip_ref.close()
         mode, content_type = ('r', 'text')
-        if not filename.lower().endswith(('html', 'css', 'txt', 'svg')):
+        if not extract_path.split('/')[-1].endswith(('html', 'css', 'txt', 'svg')):
             mode, content_type = ('rb', 'media/*')
-
         return Response(open(file_path).read())
 
 
@@ -377,8 +380,10 @@ class TwitterImageAPIView(APIView):
             image.save()
         except model.DoesNotExist:
             image = model.objects.create(title=id,
-                                         file=decode_base64_file(data=raw_image,
-                                                                 file_name=id))
+                                         file=decode_base64_file(
+                                             data=raw_image,
+                                             file_name=id
+                                         ))
 
         if image:
             # Create rendition image with width 600

--- a/takwimu/views.py
+++ b/takwimu/views.py
@@ -340,7 +340,7 @@ class FlourishView(APIView):
         Document = get_document_model()
         doc = get_object_or_404(Document, id=kwargs["document_id"])
 
-        extract_path = "index.html"
+        member = "index.html"
         if "path" in kwargs and kwargs["path"]:
             path = kwargs["path"]
 
@@ -352,7 +352,7 @@ class FlourishView(APIView):
                 if '.' not in path_part or index == len(path_parts) - 1:
                     path_parts.append(path_part)
 
-            extract_path = "/".join(path_parts)
+            member = "/".join(path_parts)
 
         try:
             zip_ref = zipfile.ZipFile(doc.file.path, "r")
@@ -360,13 +360,10 @@ class FlourishView(APIView):
             response = requests.get(doc.file.url, stream=True)
             zip_ref = zipfile.ZipFile(io.BytesIO(response.content))
 
-        file_path = zip_ref.extract(
-            extract_path, "/tmp/" + kwargs["document_id"])
+        file_path = zip_ref.extract(member, "/tmp/" + kwargs["document_id"])
         zip_ref.close()
         mode, content_type = ('r', 'text')
-        if not extract_path.split('/')[-1].endswith(
-            ('html', 'css', 'txt', 'svg')
-        ):
+        if not member.split('/')[-1].endswith( ('html', 'css', 'txt', 'svg')):
             mode, content_type = ('rb', 'media/*')
         return Response(open(file_path).read())
 


### PR DESCRIPTION
## Description

Some flourish viz have assets folders e.g. css/style.css. 
Fix our assumption that everything will be served from widget zip file root.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshot


<img width="498" alt="Screen Shot 2019-05-31 at 2 23 01 PM" src="https://user-images.githubusercontent.com/4308339/58703543-ae67d080-83b1-11e9-86be-d472f1a65397.png">

<img width="825" alt="Screen Shot 2019-05-31 at 2 37 22 PM" src="https://user-images.githubusercontent.com/4308339/58703528-a6a82c00-83b1-11e9-9487-4d170ccd304c.png">

<img width="483" alt="Screen Shot 2019-05-31 at 2 33 31 PM" src="https://user-images.githubusercontent.com/4308339/58703538-ac057680-83b1-11e9-9b30-424318e1183a.png">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation