### PR TITLE
Fix content page aside overflow and scroll

### DIFF
--- a/takwimu/takwimu_ui/src/components/AnalysisContent/index.js
+++ b/takwimu/takwimu_ui/src/components/AnalysisContent/index.js
@@ -38,7 +38,7 @@ const styles = theme => ({
     padding: '0 19px'
   },
   readNextContainer: {
-    paddingBottom: '2.3125rem'
+    paddingBottom: '2.25rem'
   },
   hero: {
     backgroundImage: `url(${profileHeroImage})`,

--- a/takwimu/takwimu_ui/src/components/TableOfContent.js
+++ b/takwimu/takwimu_ui/src/components/TableOfContent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 import { withStyles, Link, MenuList } from '@material-ui/core';
+import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
 
 import activeContentIcon from '../assets/images/active-page.svg';
 
@@ -62,7 +63,8 @@ function TableOfContent({
   content,
   current,
   generateHref,
-  onChange
+  onChange,
+  width
 }) {
   const [scrollDistance, setScrollDistance] = useState(0);
 
@@ -86,7 +88,8 @@ function TableOfContent({
       window.removeEventListener('scroll', handleScroll);
     };
   }, []);
-  const top = `${DEFAULT_TOP - scrollDistance}px`;
+  const y = isWidthUp('md', width) ? DEFAULT_TOP : 0;
+  const top = `${y - scrollDistance}px`;
   const bottom = `${scrollDistance}px`;
 
   return (
@@ -134,11 +137,12 @@ TableOfContent.propTypes = {
   content: PropTypes.arrayOf(PropTypes.shape({}).isRequired).isRequired,
   current: PropTypes.number.isRequired,
   generateHref: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  width: PropTypes.string.isRequired
 };
 
 TableOfContent.defaultProps = {
   children: null
 };
 
-export default withStyles(styles)(TableOfContent);
+export default withWidth()(withStyles(styles)(TableOfContent));

--- a/takwimu/takwimu_ui/src/components/TableOfContent.js
+++ b/takwimu/takwimu_ui/src/components/TableOfContent.js
@@ -1,23 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles, MenuList, Link } from '@material-ui/core';
 
 import classNames from 'classnames';
+import { withStyles, Link, MenuList } from '@material-ui/core';
 
 import activeContentIcon from '../assets/images/active-page.svg';
 
+const DEFAULT_TOP = 120; // Navigation height + padding
 const styles = theme => ({
   root: {
     position: 'relative',
     display: 'flex',
     justifyContent: 'flex-start',
     width: '100%',
-    height: '34rem',
     flexDirection: 'column',
     alignItems: 'flex-start',
     [theme.breakpoints.up('md')]: {
       position: 'fixed',
-      width: '14.375rem'
+      width: '14.375rem',
+      top: `${DEFAULT_TOP}px`,
+      bottom: 0,
+      overflow: 'hidden auto',
+
+      scrollbarColor: '#d3d3d3',
+      scrollbarWidth: 'thin',
+      '&::-webkit-scrollbar': {
+        width: '0.4rem'
+      },
+      '&::-webkit-scrollbar-thumb': {
+        backgroundColor: '#d3d3d3'
+      },
+      '&::-webkit-scrollbar-corner': {
+        backgroundColor: 'transparent'
+      }
     }
   },
   menuListRoot: {
@@ -49,8 +64,33 @@ function TableOfContent({
   generateHref,
   onChange
 }) {
+  const [scrollDistance, setScrollDistance] = useState(0);
+
+  useEffect(() => {
+    const calculateScrollDistance = () => {
+      const footer = document.getElementById('takwimuFooter');
+      const { top } = footer.getBoundingClientRect();
+      if (top < window.innerHeight) {
+        return window.innerHeight - top;
+      }
+      return 0;
+    };
+
+    function handleScroll() {
+      setScrollDistance(calculateScrollDistance());
+    }
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+  const top = `${DEFAULT_TOP - scrollDistance}px`;
+  const bottom = `${scrollDistance}px`;
+
   return (
-    <div className={classes.root}>
+    <div className={classes.root} style={{ top, bottom }}>
       {children}
       <MenuList classes={{ root: classes.menuListRoot }}>
         {content.map((c, index) => (

--- a/takwimu/takwimu_ui/src/pages/Analysis.js
+++ b/takwimu/takwimu_ui/src/pages/Analysis.js
@@ -11,9 +11,7 @@ const styles = () => ({
   root: {
     marginBottom: '5.5rem'
   },
-  asideRoot: {
-    marginTop: '3.1875rem'
-  }
+  asideRoot: {}
 });
 
 class AnalysisPage extends React.Component {


### PR DESCRIPTION
## Description

The `aside` component used for in page navigation in Content (**Country Analysis**, **About** and **Contact**) pages cuts of content when browser window's height is less than it's height.

This PR address this as well as enable scrolling of the `aside` content when the Content page footer comes into view.

 - [x] Show vertical scrolls when browser window's height is less than `aside` height, and
 - [x] Scroll both `aside` and `main` when footer comes into view.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2019-06-19 12-57](https://user-images.githubusercontent.com/1779590/59756457-6a6e3a00-9292-11e9-87fd-149e7aa69464.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation