### PR TITLE
Fix Carousel topic load error

### DIFF
--- a/takwimu/takwimu_ui/src/components/AnalysisContent/Actions/DownloadPDF.js
+++ b/takwimu/takwimu_ui/src/components/AnalysisContent/Actions/DownloadPDF.js
@@ -196,6 +196,12 @@ const createPdf = (Document, Image, Link, Page, Text, View) => {
   return AnalysisPDF;
 };
 
+// https://stackoverflow.com/a/32108184
+const isEmpty = obj =>
+  obj === undefined ||
+  obj === null ||
+  (Object.keys(obj).length === 0 && obj.constructor === Object);
+
 function DownloadPDF({ classes, title, topic, data, takwimu, top }) {
   const [reactPdf, setReactPdf] = useState(false);
   const [pdfBlob, setPdfBlob] = useState(null);
@@ -207,7 +213,7 @@ function DownloadPDF({ classes, title, topic, data, takwimu, top }) {
   }, []);
 
   useEffect(() => {
-    if (reactPdf) {
+    if (reactPdf && data && !isEmpty(data.item)) {
       const {
         ReactPDF,
         Document,

--- a/takwimu/takwimu_ui/src/components/AnalysisContent/Actions/DownloadPDF.js
+++ b/takwimu/takwimu_ui/src/components/AnalysisContent/Actions/DownloadPDF.js
@@ -168,7 +168,7 @@ const createPdf = (Document, Image, Link, Page, Text, View) => {
 
           <View style={classes.footer} fixed>
             <Text style={classes.downloadedAt}>
-              Dowloaded{' '}
+              Downloaded{' '}
               {new Date().toLocaleDateString('UTC', {
                 day: '2-digit',
                 month: 'short',
@@ -213,7 +213,11 @@ function DownloadPDF({ classes, title, topic, data, takwimu, top }) {
   }, []);
 
   useEffect(() => {
-    if (reactPdf && data && !isEmpty(data.item)) {
+    if (
+      reactPdf &&
+      !isEmpty(data) &&
+      (topic === 'topic' || !isEmpty(data.item))
+    ) {
       const {
         ReactPDF,
         Document,

--- a/takwimu/takwimu_ui/src/components/AnalysisContent/index.js
+++ b/takwimu/takwimu_ui/src/components/AnalysisContent/index.js
@@ -56,8 +56,13 @@ function AnalysisContent({ classes, content, topicIndex, takwimu, onChange }) {
   const [carouselItemIndex, setCarouselItemIndex] = useState(
     content.body[topicIndex].type === 'carousel_topic' ? 0 : -1
   );
-  const [id, setId] = useState(`${content.id}-${topicIndex}`);
+  useEffect(() => {
+    setCarouselItemIndex(
+      content.body[topicIndex].type === 'carousel_topic' ? 0 : -1
+    );
+  }, [topicIndex]);
 
+  const [id, setId] = useState(`${content.id}-${topicIndex}`);
   useEffect(() => {
     if (`${content.id}-${topicIndex}` !== id) {
       setId(`${content.id}-${topicIndex}`);
@@ -131,6 +136,7 @@ function AnalysisContent({ classes, content, topicIndex, takwimu, onChange }) {
 
         {content.body[topicIndex].type === 'carousel_topic' ? (
           <CarouselTopic
+            key={topicIndex}
             data={content.body[topicIndex].value.body}
             onIndexChanged={setCarouselItemIndex}
           />


### PR DESCRIPTION
## Description

On initial Carousel topic load, we currently try to load and render PDF for download without making sure that we actually have data i.e. data is not empty. This PR:

 - [x] Adds a guard to check data before rendering PDF
 - [x] Reset select carousel item whenever profile topic changes, and
 - [x] Re-renders carousel whenever profile topic changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation