### PR TITLE
Enable same-origin for HURUmap & Flourish Viz

### DIFF
--- a/takwimu/takwimu_ui/src/components/DataContainer/HurumapDataContainer.js
+++ b/takwimu/takwimu_ui/src/components/DataContainer/HurumapDataContainer.js
@@ -64,9 +64,11 @@ function DataContainer({ id, data, theme, countryName }) {
     data.data_stat_type
   }&chartSourceLink=${data.data_source_link}&chartSourceTitle=${
     data.data_source_title
-  }&chartQualifier=${data.chart_qualifier
-    .replace('<br/>', '%0A')
-    .replace(/<(.|\n)*?>/g, '')}&stylesheet=/static/css/embedchart.css"
+  }&chartQualifier=${
+    data.chart_qualifier
+      ? data.chart_qualifier.replace('<br/>', '%0A').replace(/<(.|\n)*?>/g, '')
+      : ''
+  }&stylesheet=/static/css/embedchart.css"
 />`;
 
   return (

--- a/takwimu/takwimu_ui/src/components/DataContainer/IFrame.js
+++ b/takwimu/takwimu_ui/src/components/DataContainer/IFrame.js
@@ -92,8 +92,8 @@ function IFrame({ id, classes, data }) {
     chartSourceLink: data.data_source_link,
     chartSourceTitle: data.data_source_title,
     chartQualifier: data.chart_qualifier
-      .replace(/<br[ /]*>/g, '\n')
-      .replace(/<[^>]*>/g, '')
+      ? data.chart_qualifier.replace(/<br[ /]*>/g, '\n').replace(/<[^>]*>/g, '')
+      : ''
   };
   const queryString = Object.keys(params)
     .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)

--- a/takwimu/takwimu_ui/src/index.js
+++ b/takwimu/takwimu_ui/src/index.js
@@ -163,4 +163,5 @@ renderLegalPage();
 render500Page();
 render404Page();
 
+// Same-origin policy
 document.domain = new URL(PROPS.takwimu.url).hostname;

--- a/takwimu/takwimu_ui/src/index.js
+++ b/takwimu/takwimu_ui/src/index.js
@@ -162,3 +162,5 @@ renderSearchResultsPage();
 renderLegalPage();
 render500Page();
 render404Page();
+
+document.domain = new URL(PROPS.takwimu.url).hostname;

--- a/takwimu/templates/settings_js.html
+++ b/takwimu/templates/settings_js.html
@@ -5,4 +5,7 @@
   {{ block.super }}
 
   var STATIC_PREFIX = '{% get_static_prefix %}';
+
+  // Same-origin policy for embeds
+  document.domain = new URL(SITE_URL).hostname;
 {% endblock settings_javascript %}


### PR DESCRIPTION
## Description

Enable same-origin policy for HURUmap & Flourish Viz: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Changing_origin

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1779590/64697235-0a5ded00-d4a9-11e9-845f-e42834062433.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation